### PR TITLE
Batch invoker for skill-testing

### DIFF
--- a/__mocks__/virtual-device-sdk.js
+++ b/__mocks__/virtual-device-sdk.js
@@ -1,24 +1,33 @@
 const mockMessage = jest.fn(()=>{
-  return {};  
+  return [{}];
 });
 
-const spaceFactMessage = jest.fn((utterance)=> {
-    const response = {
-        card:{
-            textField: "textField",
-            imageURL: "imageURL",
-            mainTitle: "mainTitle"
-        } 
-    };
-    if (utterance.toLowerCase().includes("help")) response.transcript = "you can say";
-    else response.transcript = "Here's your fact";
-    return response;  
+const spaceFactMessage = jest.fn((messages)=> {
+    const responses = [];
+    for (const message of messages) {
+        responses.push(handleMessage(message));
+    }
+    return responses;
 });
 
 const mockVirtualDevice = jest.fn().mockImplementation((token) => {
-    if(token === "space fact") return {message: spaceFactMessage};
-    return { message: mockMessage };
+    if(token === "space fact") return {batchMessage: spaceFactMessage};
+    return { batchMessage: mockMessage };
 });
+
+function handleMessage(message) {
+    const utterance = message.text;
+    const response = {
+        card:{
+            imageURL: "imageURL",
+            mainTitle: "mainTitle",
+            textField: "textField",
+        }
+    };
+    if (utterance.toLowerCase().includes("help")) response.transcript = "you can say";
+    else response.transcript = "Here's your fact";
+    return response;
+}
 
 exports.mockMessage = mockMessage;
 exports.mockVirtualDevice = mockVirtualDevice;

--- a/lib/runner/Invoker.js
+++ b/lib/runner/Invoker.js
@@ -10,7 +10,11 @@ exports.Invoker = class Invoker {
 
     // Takes a set of interactions and returns responses from the app
     // Takes multiple interactions because some implementations work better in batch
-    async invoke(interactions) {
+    async invokeBatch(interactions) {
+        return Promise.reject("This method must be implemented if batch mode is supported");
+    }
+
+    async invoke(interaction) {
         return Promise.reject("This method must be implemented");
     }
 
@@ -22,7 +26,7 @@ exports.Invoker = class Invoker {
         // Do whatever is necessary after the test
     }
 
-    batchMode() {
+    batchSupported() {
         return false;
     }
 

--- a/lib/runner/Invoker.js
+++ b/lib/runner/Invoker.js
@@ -8,8 +8,9 @@ exports.Invoker = class Invoker {
         this._runner = runner;
     }
 
-    // Returns an implementation of ResponseMapper tailored to the invoker
-    async invoke() {
+    // Takes a set of interactions and returns responses from the app
+    // Takes multiple interactions because some implementations work better in batch
+    async invoke(interactions) {
         return Promise.reject("This method must be implemented");
     }
 
@@ -19,6 +20,10 @@ exports.Invoker = class Invoker {
 
     afterTest(test) {
         // Do whatever is necessary after the test
+    }
+
+    batchMode() {
+        return false;
     }
 
     before(testSuite) {
@@ -33,8 +38,13 @@ exports.Invoker = class Invoker {
 // InvokerResponse contains the response elements that should be handled
 // Values that are available listed in an array in the provides method
 exports.InvokerResponse = class InvokerResponse {
-    constructor(sourceJSON) {
+    constructor(interaction, sourceJSON) {
+        this._interaction = interaction;
         this._sourceJSON = sourceJSON;
+    }
+
+    get interaction() {
+        return this._interaction;
     }
 
     get json() {

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -75,7 +75,7 @@ module.exports = class TestRunner {
     }
 
     async batchRun(invoker, testSuite, interactions) {
-        const responses = await this.invokeBatch(interactions);
+        const responses = await invoker.invokeBatch(interactions);
 
         // Add short-hand properties to each response
         responses.forEach((response) => response.inject());

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -59,7 +59,7 @@ module.exports = class TestRunner {
             // Process through the interactions
             // If there is a goto or this is not a batch invoker, run them one-by-one
             let results;
-            if (test.hasGoto || !invoker.batchMode()) {
+            if (test.hasGoto || !invoker.batchSupported()) {
                 results = await this.sequentialRun(invoker, testSuite, test.interactions);
 
             } else {
@@ -75,7 +75,9 @@ module.exports = class TestRunner {
     }
 
     async batchRun(invoker, testSuite, interactions) {
-        const responses = await this.invoke(invoker, testSuite, interactions);
+        const responses = await this.invokeBatch(interactions);
+        responses.forEach((response) => response.inject());
+
         const interactionResults = [];
         for (const response of responses) {
             interactionResults.push(this.processResponse(response));
@@ -96,15 +98,18 @@ module.exports = class TestRunner {
                 }
             }
 
-            let responses;
+            let response;
             try {
-                responses = await this.invoke(invoker, testSuite, [interaction]);
+                response = await invoker.invoke(interaction);
             } catch (e) {
                 results.push(this.handleException(interaction, e));
                 continue;
             }
 
-            const interactionResult = this.processResponse(responses[0]);
+            // Add short-hand properties to the response
+            response.inject();
+
+            const interactionResult = this.processResponse(response);
             if (interactionResult.goto) {
                 // If this result is a goto, set the goto label
                 goto = interactionResult.goto;
@@ -118,13 +123,6 @@ module.exports = class TestRunner {
         }
 
         return results;
-    }
-
-    async invoke(invoker, testSuite, interactions) {
-        const responses = await invoker.invoke(interactions);
-        responses.forEach((response) => response.inject());
-
-        return responses;
     }
 
     processResponse(response) {

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -76,12 +76,12 @@ module.exports = class TestRunner {
 
     async batchRun(invoker, testSuite, interactions) {
         const responses = await this.invokeBatch(interactions);
+
+        // Add short-hand properties to each response
         responses.forEach((response) => response.inject());
 
-        const interactionResults = [];
-        for (const response of responses) {
-            interactionResults.push(this.processResponse(response));
-        }
+        // Turn the responses into interaction results
+        const interactionResults = responses.map((response) => this.processResponse(response));
         return interactionResults;
     }
 

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -151,7 +151,7 @@ module.exports = class TestRunner {
             } else if (!assertion.goto) {
                 // If it did not pass, and was NOT a goto, then it is a failure
                 // We do not consider tests that end in goto statements failures if they do not match
-                const error = assertion.toString(response, testSuite.fileName);
+                const error = assertion.toString(response.json);
                 result = new InteractionResult(interaction, assertion, error);
                 break;
             }

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -57,32 +57,16 @@ module.exports = class TestRunner {
             }
 
             // Process through the interactions
-            // Look for goto statements and exits, which will affect the sequence
-            let goto;
-            for (const interaction of test.interactions) {
-                // If a goto is set, keep skipping until we match it
-                if (goto) {
-                    if (goto === interaction.utterance) {
-                        goto = undefined;
-                    } else {
-                        continue;
-                    }
-                }
+            // If there is a goto or this is not a batch invoker, run them one-by-one
+            let results;
+            if (test.hasGoto || !invoker.batchMode()) {
+                results = await this.sequentialRun(invoker, testSuite, test.interactions);
 
-                const interactionResult = await this.interact(invoker, testSuite, test, interaction);
-                if (interactionResult.goto) {
-                    // If this result is a goto, set the goto label
-                    goto = interactionResult.goto;
-                }
-
-                testResult.addInteractionResult(interactionResult);
-
-                if (interactionResult.exited) {
-                    // If this is an exit, stop processing
-                    break;
-                }
+            } else {
+                results = await this.batchRun(invoker, testSuite, test.interactions);
             }
 
+            testResult.interactionResults = results;
             invoker.afterTest(test);
         }
 
@@ -90,29 +74,62 @@ module.exports = class TestRunner {
         return testResults;
     }
 
-    async interact(invoker, testSuite, test, interaction) {
-        if (testSuite.trace) {
-            // eslint-disable-next-line no-console
-            console.log("File: " +  testSuite.shortFileName + " Test: " + test.description + " Utterance: " + interaction.utterance);
+    async batchRun(invoker, testSuite, interactions) {
+        const responses = await this.invoke(invoker, testSuite, interactions);
+        const interactionResults = [];
+        for (const response of responses) {
+            interactionResults.push(this.processResponse(response));
         }
+        return interactionResults;
+    }
 
-        let response;
-        try {
-            response = await invoker.invoke(interaction);
-        } catch (e) {
-            // We do special-handling for these errors
-            if (e.message.startsWith("Unable to match utterance:")
-                || e.message.startsWith("Interaction model has no intentName named")) {
-                const message = Util.errorMessageWithLine(e.message, testSuite.fileName, interaction.lineNumber);
-                return new InteractionResult(interaction, undefined, message);
-            } else {
-                return new InteractionResult(interaction, undefined, e.message + "\n" + e.stack);
+    async sequentialRun(invoker, testSuite, interactions) {
+        let goto;
+        const results = [];
+        for (const interaction of interactions) {
+            // If a goto is set, keep skipping until we match it
+            if (goto) {
+                if (goto === interaction.utterance) {
+                    goto = undefined;
+                } else {
+                    continue;
+                }
+            }
+
+            let responses;
+            try {
+                responses = await this.invoke(invoker, testSuite, [interaction]);
+            } catch (e) {
+                results.push(this.handleException(interaction, e));
+                continue;
+            }
+
+            const interactionResult = this.processResponse(responses[0]);
+            if (interactionResult.goto) {
+                // If this result is a goto, set the goto label
+                goto = interactionResult.goto;
+            }
+
+            results.push(interactionResult);
+            if (interactionResult.exited) {
+                // If this is an exit, stop processing
+                break;
             }
         }
 
-        // Add shorthand values like prompt and re-prompt to the response
-        response.inject();
+        return results;
+    }
 
+    async invoke(invoker, testSuite, interactions) {
+        const responses = await invoker.invoke(interactions);
+        responses.forEach((response) => response.inject());
+
+        return responses;
+    }
+
+    processResponse(response) {
+        const interaction = response.interaction;
+        const testSuite = interaction.test.testSuite;
         let result = new InteractionResult(interaction);
         for (const assertion of interaction.assertions) {
             if (assertion.exit) {
@@ -160,10 +177,25 @@ module.exports = class TestRunner {
     filterRequest(interaction, request) {
         interaction.applyExpressions(request);
 
-        if (interaction.test.testSuite.trace) {
+        const testSuite = interaction.test.testSuite;
+        if (testSuite.trace) {
+            const test = interaction.test;
+            // eslint-disable-next-line no-console
+            console.log("File: " +  testSuite.shortFileName + " Test: " + test.description + " Utterance: " + interaction.utterance);
+
             // eslint-disable-next-line no-console
             console.log(chalk.hex("#ff6633")("Request Envelope:\n" + JSON.stringify(request, null, 2)));
         }
     }
-}
 
+    handleException(interaction, e) {
+        const testSuite = interaction.test.testSuite;
+        if (e.message.startsWith("Unable to match utterance:")
+            || e.message.startsWith("Interaction model has no intentName named")) {
+            const message = Util.errorMessageWithLine(e.message, testSuite.fileName, interaction.lineNumber);
+            return new InteractionResult(interaction, undefined, message);
+        } else {
+            return new InteractionResult(interaction, undefined, e.message + "\n" + e.stack);
+        }
+    }
+}

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -159,7 +159,7 @@ module.exports = class TestRunner {
 
         if (testSuite.trace) {
             // eslint-disable-next-line no-console
-            console.log(chalk.cyan("Response Envelope:\n" + JSON.stringify(response, null, 2)));
+            console.log(chalk.cyan("Response Envelope:\n" + JSON.stringify(response.json, null, 2)));
         }
 
         return result;

--- a/lib/runner/VirtualAlexaInvoker.js
+++ b/lib/runner/VirtualAlexaInvoker.js
@@ -57,7 +57,16 @@ module.exports = class VirtualAlexaInvoker extends Invoker {
         }
     }
 
-    async invoke(interaction) {
+    async invoke(interactions) {
+        const responses = [];
+        for (const interaction of interactions) {
+            const response = await this.invokeOne(interaction);
+            responses.push(response);
+        }
+        return responses;
+    }
+
+    async invokeOne(interaction) {
         // We always use a filter to apply expressions
         this._virtualAlexa.filter((request) => {
             this._runner.filterRequest(interaction, request);
@@ -77,13 +86,13 @@ module.exports = class VirtualAlexaInvoker extends Invoker {
                 response = await this._virtualAlexa.utter(interaction.utterance)
             }
         }
-        return new VirtualAlexaResponse(response);
+        return new VirtualAlexaResponse(interaction, response);
     }
 }
 
 class VirtualAlexaResponse extends InvokerResponse {
-    constructor(sourceJSON) {
-        super(sourceJSON);
+    constructor(interaction, sourceJSON) {
+        super(interaction, sourceJSON);
     }
 
     cardContent() {

--- a/lib/runner/VirtualAlexaInvoker.js
+++ b/lib/runner/VirtualAlexaInvoker.js
@@ -57,16 +57,16 @@ module.exports = class VirtualAlexaInvoker extends Invoker {
         }
     }
 
-    async invoke(interactions) {
+    async invokeBatch(interactions) {
         const responses = [];
         for (const interaction of interactions) {
-            const response = await this.invokeOne(interaction);
+            const response = await this.invoke(interaction);
             responses.push(response);
         }
         return responses;
     }
 
-    async invokeOne(interaction) {
+    async invoke(interaction) {
         // We always use a filter to apply expressions
         this._virtualAlexa.filter((request) => {
             this._runner.filterRequest(interaction, request);

--- a/lib/runner/VirtualDeviceInvoker.js
+++ b/lib/runner/VirtualDeviceInvoker.js
@@ -21,6 +21,8 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
     async invoke(interactions) {
         const messages = [];
 
+        // Keep an array of the actual interactions sent, as some may be skipped
+        const messageInteractions = [];
         for (const interaction of interactions) {
             const utterance = this.convertUtterance(interaction);
             if (!utterance) {
@@ -28,10 +30,10 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
             }
 
             const message = {
-                interaction: interaction,
                 phrases: [],
                 text: utterance,
             };
+            messageInteractions.push(interaction);
 
             if (interaction.assertions) {
                 for (const assertion of interaction.assertions) {
@@ -56,7 +58,7 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
 
         const responses = [];
         for (let i = 0 ;i < results.length; i++) {
-            responses.push(new VirtualDeviceResponse(messages[i].interaction, results[i]));
+            responses.push(new VirtualDeviceResponse(messageInteractions[i], results[i]));
         }
         return responses;
     }

--- a/lib/runner/VirtualDeviceInvoker.js
+++ b/lib/runner/VirtualDeviceInvoker.js
@@ -18,7 +18,7 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
         this._virtualDevice = new VirtualDevice(testSuite.virtualDeviceToken, locale, voiceId);
     }
 
-    async invoke(interactions) {
+    async invokeBatch(interactions) {
         const messages = [];
 
         // Keep an array of the actual interactions sent, as some may be skipped
@@ -61,6 +61,15 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
             responses.push(new VirtualDeviceResponse(messageInteractions[i], results[i]));
         }
         return responses;
+    }
+
+    async invoke(interaction) {
+        const responses = await this.invokeBatch([interaction]);
+        let response;
+        if (responses && responses.length > 0) {
+            response = responses[0];
+        }
+        return response;
     }
 
     convertUtterance(interaction) {

--- a/lib/runner/VirtualDeviceInvoker.js
+++ b/lib/runner/VirtualDeviceInvoker.js
@@ -8,7 +8,7 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
         super(runner);
     }
 
-    batchMode() {
+    batchSupported() {
         return true;
     }
 

--- a/lib/runner/VirtualDeviceInvoker.js
+++ b/lib/runner/VirtualDeviceInvoker.js
@@ -8,35 +8,79 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
         super(runner);
     }
 
+    batchMode() {
+        return true;
+    }
+
     before(testSuite) {
         const locale = testSuite.locale || undefined;
         const voiceId = testSuite.voiceId || undefined;
         this._virtualDevice = new VirtualDevice(testSuite.virtualDeviceToken, locale, voiceId);
     }
 
-    async invoke(interaction) {
-        let message;
+    async invoke(interactions) {
+        const messages = [];
+
+        for (const interaction of interactions) {
+            const utterance = this.convertUtterance(interaction);
+            if (!utterance) {
+                continue;
+            }
+
+            const message = {
+                interaction: interaction,
+                phrases: [],
+                text: utterance,
+            };
+
+            if (interaction.assertions) {
+                for (const assertion of interaction.assertions) {
+                    // If this is a check on the prompt or the transcript
+                    //  we add the expected value as a phrase - this helps with speech recognition
+                    if ((assertion.path === "prompt" ||
+                        assertion.path === "transcript")
+                        && (assertion.operator === "==" ||
+                            assertion.operator === "=~")) {
+                        message.phrases.push(assertion.value);
+                    }
+                }
+            }
+
+            messages.push(message);
+        }
+
+        let results = [];
+        if (messages.length > 0) {
+            results = await this._virtualDevice.batchMessage(messages);
+        }
+
+        const responses = [];
+        for (let i = 0 ;i < results.length; i++) {
+            responses.push(new VirtualDeviceResponse(messages[i].interaction, results[i]));
+        }
+        return responses;
+    }
+
+    convertUtterance(interaction) {
+        let utterance = interaction.utterance;
         if (interaction.utterance === "LaunchRequest") {
-            message = `open ${interaction.test.testSuite.invocationName}`;
+            utterance = `open ${interaction.test.testSuite.invocationName}`;
         } else if (interaction.utterance.startsWith("AudioPlayer.")) {
-            return new VirtualDeviceResponse({});
+            utterance = undefined;
         } else if (interaction.utterance === "SessionEndedRequest") {
-            message = "exit";
+            utterance = "exit";
         } else {
             if (interaction.relativeIndex === 0) {
-                message = `ask ${interaction.test.testSuite.invocationName} to ${interaction.utterance}`;
-            } else {
-                message = interaction.utterance;
+                utterance = `ask ${interaction.test.testSuite.invocationName} to ${interaction.utterance}`;
             }
         }
-        const response = await this._virtualDevice.message(message);
-        return new VirtualDeviceResponse(response);
+        return utterance;
     }
 }
 
 class VirtualDeviceResponse extends InvokerResponse {
-    constructor(sourceJSON) {
-        super(sourceJSON);
+    constructor(interaction, sourceJSON) {
+        super(interaction, sourceJSON);
     }
 
     cardContent() {

--- a/lib/test/Test.js
+++ b/lib/test/Test.js
@@ -22,12 +22,12 @@ module.exports = class Test {
         return this._description;
     }
 
-    get interactions() {
-        return this._interactions;
+    get hasGoto() {
+        return this.interactions.find((interaction) => interaction.hasGoto);
     }
 
-    get testSuite() {
-        return this._testSuite;
+    get interactions() {
+        return this._interactions;
     }
 
     get only() {
@@ -44,6 +44,10 @@ module.exports = class Test {
 
     set skip(skip) {
         this._skip = skip;
+    }
+
+    get testSuite() {
+        return this._testSuite;
     }
 
     // Make sure all any goto statements work

--- a/lib/test/TestInteraction.js
+++ b/lib/test/TestInteraction.js
@@ -16,6 +16,10 @@ module.exports = class TestInteraction {
         return this._requestExpressions;
     }
 
+    get hasGoto() {
+        return this.assertions.find((assertion) => assertion.goto !== undefined);
+    }
+
     get intent() {
         return this._intent;
     }

--- a/lib/test/TestResult.js
+++ b/lib/test/TestResult.js
@@ -12,6 +12,10 @@ exports.TestResult = class TestResult {
         return this._interactionResults;
     }
 
+    set interactionResults(results) {
+        this._interactionResults = results;
+    }
+
     get skipped() {
         return this._test.skip;
     }

--- a/lib/test/TestSuite.js
+++ b/lib/test/TestSuite.js
@@ -8,14 +8,6 @@ module.exports = class TestSuite {
         this._tests = tests;
     }
 
-    get invocationName() {
-        return Configuration.instance().value("invocationName", this.configuration);
-    }
-
-    get virtualDeviceToken() {
-        return Configuration.instance().value("virtualDeviceToken", this.configuration);
-    }
-
     get accountToken() {
         return Configuration.instance().value("accountToken", this.configuration);
     }
@@ -44,17 +36,21 @@ module.exports = class TestSuite {
         return this._fileName;
     }
 
-    get handler() {
-        return Configuration.instance().value("handler", this.configuration, "index.handler");
-    }
-
     set fileName(name) {
         this._fileName = name;
+    }
+
+    get handler() {
+        return Configuration.instance().value("handler", this.configuration, "index.handler");
     }
 
     get interactionModel() {
         const defaultValue = "models/" + this.locale + ".json";
         return Configuration.instance().value("interactionModel", this.configuration, defaultValue);
+    }
+
+    get invocationName() {
+        return Configuration.instance().value("invocationName", this.configuration);
     }
 
     get invoker() {
@@ -83,6 +79,10 @@ module.exports = class TestSuite {
 
     get userId() {
         return Configuration.instance().value("userId", this.configuration);
+    }
+
+    get virtualDeviceToken() {
+        return Configuration.instance().value("virtualDeviceToken", this.configuration);
     }
 
     // Process the skip and only flags

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "js-yaml-bespoken": "^3.11.3",
     "jsonpath": "^1.0.0",
     "lodash": "^4.17.5",
-    "virtual-alexa": "^0.6.5"
+    "virtual-alexa": "^0.6.5",
+    "virtual-device-sdk": "^1.4.5"
   },
   "devDependencies": {
     "alexa-sdk": "^1.0.25",

--- a/test/Assertion.test.js
+++ b/test/Assertion.test.js
@@ -156,7 +156,7 @@ describe("assertion", () => {
 
 class MockResponse extends InvokerResponse {
     constructor(sourceJSON) {
-        super(sourceJSON);
+        super(undefined, sourceJSON);
     }
 
     ignoreCase(path) {

--- a/test/VirtualDeviceInvoker.test.js
+++ b/test/VirtualDeviceInvoker.test.js
@@ -27,7 +27,7 @@ describe("virtual device integration", () => {
         test("LaunchRequest", async () => {
             _interaction.utterance = "LaunchRequest";
     
-            await _invoker.invoke([_interaction]);
+            await _invoker.invoke(_interaction);
     
             expect(message).toHaveBeenCalledTimes(1);
             expect(message.mock.calls[0][0][0].text).toBe("open space fact");
@@ -36,7 +36,7 @@ describe("virtual device integration", () => {
         test("AudioPlayer", async () => {
             _interaction.utterance = "AudioPlayer.";
     
-            await _invoker.invoke([_interaction]);
+            await _invoker.invokeBatch([_interaction]);
     
             expect(message).not.toHaveBeenCalled();
         });
@@ -44,7 +44,7 @@ describe("virtual device integration", () => {
         test("SessionEndedRequest", async () => {
             _interaction.utterance = "SessionEndedRequest";
     
-            await _invoker.invoke([_interaction]);
+            await _invoker.invokeBatch([_interaction]);
     
             expect(message).toHaveBeenCalledTimes(1);
             expect(message.mock.calls[0][0][0].text).toBe("exit");
@@ -54,7 +54,7 @@ describe("virtual device integration", () => {
             _interaction.utterance = "hi";
             _interaction.relativeIndex = 0;
     
-            await _invoker.invoke([_interaction]);
+            await _invoker.invokeBatch([_interaction]);
     
             expect(message).toHaveBeenCalledTimes(1);
             expect(message.mock.calls[0][0][0].text).toBe("ask space fact to hi");
@@ -64,7 +64,7 @@ describe("virtual device integration", () => {
             _interaction.utterance = "test";
             _interaction.relativeIndex = 1;
     
-            await _invoker.invoke([_interaction]);
+            await _invoker.invokeBatch([_interaction]);
     
             expect(message).toHaveBeenCalledTimes(1);
             expect(message.mock.calls[0][0][0].text).toBe("test");
@@ -74,7 +74,7 @@ describe("virtual device integration", () => {
             _interaction.utterance = "test";
             _interaction.relativeIndex = 1;
     
-            await _invoker.invoke([_interaction]);
+            await _invoker.invokeBatch([_interaction]);
     
             expect(message).toHaveBeenCalledTimes(1);
             expect(message.mock.calls[0][0][0].text).toBe("test");

--- a/test/VirtualDeviceInvoker.test.js
+++ b/test/VirtualDeviceInvoker.test.js
@@ -27,16 +27,16 @@ describe("virtual device integration", () => {
         test("LaunchRequest", async () => {
             _interaction.utterance = "LaunchRequest";
     
-            await _invoker.invoke(_interaction);
+            await _invoker.invoke([_interaction]);
     
             expect(message).toHaveBeenCalledTimes(1);
-            expect(message).toHaveBeenCalledWith("open space fact");
+            expect(message.mock.calls[0][0][0].text).toBe("open space fact");
         });
     
         test("AudioPlayer", async () => {
             _interaction.utterance = "AudioPlayer.";
     
-            await _invoker.invoke(_interaction);
+            await _invoker.invoke([_interaction]);
     
             expect(message).not.toHaveBeenCalled();
         });
@@ -44,40 +44,40 @@ describe("virtual device integration", () => {
         test("SessionEndedRequest", async () => {
             _interaction.utterance = "SessionEndedRequest";
     
-            await _invoker.invoke(_interaction);
+            await _invoker.invoke([_interaction]);
     
             expect(message).toHaveBeenCalledTimes(1);
-            expect(message).toHaveBeenCalledWith("exit");
+            expect(message.mock.calls[0][0][0].text).toBe("exit");
         });
     
         test("First interaction is not a launch request", async () => {
             _interaction.utterance = "hi";
             _interaction.relativeIndex = 0;
     
-            await _invoker.invoke(_interaction);
+            await _invoker.invoke([_interaction]);
     
             expect(message).toHaveBeenCalledTimes(1);
-            expect(message).toHaveBeenCalledWith("ask space fact to hi");
+            expect(message.mock.calls[0][0][0].text).toBe("ask space fact to hi");
         });
     
         test("Any utterance", async () => {
             _interaction.utterance = "test";
             _interaction.relativeIndex = 1;
     
-            await _invoker.invoke(_interaction);
+            await _invoker.invoke([_interaction]);
     
             expect(message).toHaveBeenCalledTimes(1);
-            expect(message).toHaveBeenCalledWith("test");
+            expect(message.mock.calls[0][0][0].text).toBe("test");
         });
 
         test("Response", async () => {
             _interaction.utterance = "test";
             _interaction.relativeIndex = 1;
     
-            await _invoker.invoke(_interaction);
+            await _invoker.invoke([_interaction]);
     
             expect(message).toHaveBeenCalledTimes(1);
-            expect(message).toHaveBeenCalledWith("test");
+            expect(message.mock.calls[0][0][0].text).toBe("test");
         });
     });
 


### PR DESCRIPTION
Allows for running virtual devices in batch. This is important for managing session interactions correctly - without it, sessions with Alexa are likely to timeout.

This refactors Invoker so it supports an optional invokeBatch routine. If the flag batchSupported is set to true, then this will be preferred for calls to the invoker.

When invokeBatch is called, many interactions will be sent, and many responses are expected in return. The response also contains now the interaction object, to track which response correlates to which interaction. 