### PR TITLE
Request/response filtering capability

### DIFF
--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -131,10 +131,8 @@ module.exports = class TestRunner {
 
         // We check if a filter object is defined
         // If so, it gives the test writer a chance to make changes to the response
-        if (testSuite.filterObject()) {
-            if (testSuite.filterObject().onResponse) {
-                testSuite.filterObject().onResponse(interaction.test, response.json);
-            }
+        if (testSuite.filterObject() && testSuite.filterObject().onResponse) {
+            testSuite.filterObject().onResponse(interaction.test, response.json);
         }
 
         let result = new InteractionResult(interaction);
@@ -187,10 +185,8 @@ module.exports = class TestRunner {
         // We check if a filter object is defined
         // If so, it gives the test writer a chance to make changes to the request
         const testSuite = interaction.test.testSuite;
-        if (testSuite.filterObject()) {
-            if (testSuite.filterObject().onRequest) {
-                testSuite.filterObject().onRequest(interaction.test, request);
-            }
+        if (testSuite.filterObject() && testSuite.filterObject().onRequest) {
+            testSuite.filterObject().onRequest(interaction.test, request);
         }
 
         if (testSuite.trace) {

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -128,6 +128,15 @@ module.exports = class TestRunner {
     processResponse(response) {
         const interaction = response.interaction;
         const testSuite = interaction.test.testSuite;
+
+        // We check if a filter object is defined
+        // If so, it gives the test writer a chance to make changes to the response
+        if (testSuite.filterObject()) {
+            if (testSuite.filterObject().onResponse) {
+                testSuite.filterObject().onResponse(interaction.test, response.json);
+            }
+        }
+
         let result = new InteractionResult(interaction);
         for (const assertion of interaction.assertions) {
             if (assertion.exit) {
@@ -175,7 +184,15 @@ module.exports = class TestRunner {
     filterRequest(interaction, request) {
         interaction.applyExpressions(request);
 
+        // We check if a filter object is defined
+        // If so, it gives the test writer a chance to make changes to the request
         const testSuite = interaction.test.testSuite;
+        if (testSuite.filterObject()) {
+            if (testSuite.filterObject().onRequest) {
+                testSuite.filterObject().onRequest(interaction.test, request);
+            }
+        }
+
         if (testSuite.trace) {
             const test = interaction.test;
             // eslint-disable-next-line no-console

--- a/lib/test/TestSuite.js
+++ b/lib/test/TestSuite.js
@@ -8,6 +8,10 @@ module.exports = class TestSuite {
         this._tests = tests;
     }
 
+    get filter() {
+        return Configuration.instance().value("filter", this.configuration);
+    }
+
     get intentSchema() {
         return Configuration.instance().value("intentSchema", this.configuration);
     }
@@ -99,6 +103,15 @@ module.exports = class TestSuite {
 
     get virtualDeviceToken() {
         return Configuration.instance().value("virtualDeviceToken", this.configuration);
+    }
+
+    filterObject() {
+        let filterModule = this.filter;
+        if (filterModule) {
+            filterModule = path.join(process.cwd(), filterModule);
+        }
+
+        return filterModule ? require(filterModule) : undefined;
     }
 
     // Process the skip and only flags

--- a/lib/test/TestSuite.js
+++ b/lib/test/TestSuite.js
@@ -24,8 +24,8 @@ module.exports = class TestSuite {
         return Configuration.instance().value("homophones", this.configuration);
     }
 
-    get accountToken() {
-        return Configuration.instance().value("accountToken", this.configuration);
+    get accessToken() {
+        return Configuration.instance().value("accessToken", this.configuration);
     }
 
     get address() {

--- a/lib/test/TestSuite.js
+++ b/lib/test/TestSuite.js
@@ -107,11 +107,18 @@ module.exports = class TestSuite {
 
     filterObject() {
         let filterModule = this.filter;
+        let filterObject;
         if (filterModule) {
             filterModule = path.join(process.cwd(), filterModule);
+            try {
+                filterObject = require(filterModule);
+            } catch (e) {
+                // eslint-disable-next-line no-console
+                console.error("Filter specified - but filter module not found at: " + filterModule);
+            }
         }
 
-        return filterModule ? require(filterModule) : undefined;
+        return filterObject;
     }
 
     // Process the skip and only flags

--- a/test/AddressSkill/short-address-test.yml
+++ b/test/AddressSkill/short-address-test.yml
@@ -5,7 +5,6 @@ configuration:
   address:
     countryCode: US
     postalCode: 20816
-  filter: filter.js
 
 ---
 - test: "Has postal code"

--- a/test/AddressSkill/short-address-test.yml
+++ b/test/AddressSkill/short-address-test.yml
@@ -1,0 +1,14 @@
+# Test created by Bespoken - to use this test, go to https://bespoken.io/testing
+--- # Configuration YAML document
+configuration:
+  locale: en-US
+  address:
+    countryCode: US
+    postalCode: 20816
+  filter: filter.js
+
+---
+- test: "Has postal code"
+- LaunchRequest:
+  - payload.postalCode: 20816
+

--- a/test/FilterSkill/filter-test.yml
+++ b/test/FilterSkill/filter-test.yml
@@ -2,12 +2,11 @@
 --- # Configuration YAML document
 configuration:
   locale: en-US
-  address:
-    countryCode: US
-    postalCode: 20816
 
 ---
 - test: "Has postal code"
 - LaunchRequest:
-  - payload.postalCode: 20816
+  - requestFiltered: true
+  - responseFiltered: true
+  - accessToken: testToken
 

--- a/test/FilterSkill/filter.js
+++ b/test/FilterSkill/filter.js
@@ -1,0 +1,9 @@
+module.exports = {
+    onRequest: (test, request) => {
+        request.requestFiltered = true;
+    },
+
+    onResponse: (test, response) => {
+        response.responseFiltered = true;
+    }
+}

--- a/test/FilterSkill/index.js
+++ b/test/FilterSkill/index.js
@@ -1,0 +1,12 @@
+exports.handler = function(event, context) {
+    const response = {};
+    if (event.session.user.accessToken) {
+        response.accessToken = event.session.user.accessToken;
+    }
+
+    if (event.requestFiltered) {
+        response.requestFiltered = true;
+    }
+
+    context.done(null, response);
+}

--- a/test/VirtualAlexaInvoker.test.js
+++ b/test/VirtualAlexaInvoker.test.js
@@ -183,7 +183,7 @@ describe("virtual alexa runner", () => {
     });
 
     describe("filter tests", () => {
-                afterEach(() => {
+        afterEach(() => {
             Configuration.singleton = undefined;
         });
 

--- a/test/VirtualAlexaInvoker.test.js
+++ b/test/VirtualAlexaInvoker.test.js
@@ -183,26 +183,40 @@ describe("virtual alexa runner", () => {
     });
 
     describe("filter tests", () => {
-        beforeEach(() => {
-            return Configuration.configure({
+                afterEach(() => {
+            Configuration.singleton = undefined;
+        });
+
+        test("filter is applied to request and response", async () => {
+            Configuration.configure({
                 accessToken: "testToken",
                 filter: "test/FilterSkill/filter",
                 handler: "test/FilterSkill/index.handler",
                 interactionModel: "test/FactSkill/models/en-US.json",
                 locale: "en-US"
             });
-        });
 
-        afterEach(() => {
-            Configuration.singleton = undefined;
-        });
-
-        test("filter is applied to request and response", async () => {
             const runner = new TestRunner();
 
             const results = await runner.run("test/FilterSkill/filter-test.yml");
             expect(results.length).toEqual(1);
             expect(results[0].interactionResults[0].error).toBeUndefined();
+        });
+
+        test("filter is applied to request and response", async () => {
+            Configuration.configure({
+                accessToken: "testToken",
+                filter: "test/FilterSkill/filter-typo",
+                handler: "test/FilterSkill/index.handler",
+                interactionModel: "test/FactSkill/models/en-US.json",
+                locale: "en-US"
+            });
+
+            const runner = new TestRunner();
+
+            const results = await runner.run("test/FilterSkill/filter-test.yml");
+            expect(results.length).toEqual(1);
+            expect(results[0].interactionResults[0].error).toBeDefined();
         });
 
     });

--- a/test/VirtualAlexaInvoker.test.js
+++ b/test/VirtualAlexaInvoker.test.js
@@ -182,6 +182,31 @@ describe("virtual alexa runner", () => {
         });
     });
 
+    describe("filter tests", () => {
+        beforeEach(() => {
+            return Configuration.configure({
+                accessToken: "testToken",
+                filter: "test/FilterSkill/filter",
+                handler: "test/FilterSkill/index.handler",
+                interactionModel: "test/FactSkill/models/en-US.json",
+                locale: "en-US"
+            });
+        });
+
+        afterEach(() => {
+            Configuration.singleton = undefined;
+        });
+
+        test("filter is applied to request and response", async () => {
+            const runner = new TestRunner();
+
+            const results = await runner.run("test/FilterSkill/filter-test.yml");
+            expect(results.length).toEqual(1);
+            expect(results[0].interactionResults[0].error).toBeUndefined();
+        });
+
+    });
+
     describe("control flow tests", () => {
         beforeAll(() => {
             return Configuration.configure({


### PR DESCRIPTION
Adds ability to specify a module that will be used to:
* Filter requests before they are sent to the skill
* Filter responses before assertions are applied to them

Additionally, fixes bug with setting the access token
