### PR TITLE
Mark testSuite as skipped if all their tests are skipped

### DIFF
--- a/lib/runner/JestAdapter.js
+++ b/lib/runner/JestAdapter.js
@@ -45,17 +45,14 @@ module.exports = async function testRunner(globalConfig, config, environment, ru
         jestResults = [asJestResult(e.test, e.message, e.interaction)];
     }
 
+    const allTestsSkipped = (failing + passing === 0);
+
     const failureMessage = JestMessageUtil.formatResultsErrors(
         jestResults,
         config,
         globalConfig,
         testPath,
     );
-    
-    // Workaround to display error when there are only skipped tests
-    if (failing + passing === 0) {
-        failing = 1;
-    }
 
     return {
         console: null,
@@ -66,7 +63,7 @@ module.exports = async function testRunner(globalConfig, config, environment, ru
         numFailingTests: failing,
         numPassingTests: passing,
         numPendingTests: pending,
-        skipped: false,
+        skipped: allTestsSkipped,
         snapshot: {
             added: 0,
             fileDeleted: false,

--- a/lib/runner/JestAdapter.js
+++ b/lib/runner/JestAdapter.js
@@ -25,6 +25,8 @@ module.exports = async function testRunner(globalConfig, config, environment, ru
     let failing = 0;
     let pending = 0;
 
+    let doResultsHaveErrorMessages = false;
+
     try {
         const results = await runner.run(testPath);
         jestResults = transformResults(results);
@@ -40,12 +42,21 @@ module.exports = async function testRunner(globalConfig, config, environment, ru
             }
         }
 
+        doResultsHaveErrorMessages = jestResults.some(
+            jestResult => jestResult.failureMessages && jestResult.failureMessages.length
+        );
+
     } catch (e) {
         failing = 1;
         jestResults = [asJestResult(e.test, e.message, e.interaction)];
     }
 
     const allTestsSkipped = (failing + passing === 0);
+
+    // This means tests are skipped by ignoring external errors and everything failed
+    if (allTestsSkipped && doResultsHaveErrorMessages) {
+        failing = 1;
+    }
 
     const failureMessage = JestMessageUtil.formatResultsErrors(
         jestResults,
@@ -63,7 +74,7 @@ module.exports = async function testRunner(globalConfig, config, environment, ru
         numFailingTests: failing,
         numPassingTests: passing,
         numPendingTests: pending,
-        skipped: allTestsSkipped,
+        skipped: !doResultsHaveErrorMessages && allTestsSkipped,
         snapshot: {
             added: 0,
             fileDeleted: false,

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -90,6 +90,8 @@ module.exports = class TestRunner {
             const testResult = new TestResult(test);
             testResults.push(testResult);
             if (test.skip) {
+                await invoker.afterTest(test);
+                // if we skip we still need to do the after test in case is closing something like in VGA
                 continue;
             }
 

--- a/lib/test/TestResult.js
+++ b/lib/test/TestResult.js
@@ -20,9 +20,9 @@ exports.TestResult = class TestResult {
     get skipped() {
         if (this.test && this.test.testSuite && this.test.testSuite.ignoreExternalErrors) {
             const errorOnProcess = this.interactionResults.some(r => r.errorOnProcess);
-            return this._test.skip || errorOnProcess;
+            return this.test.skip || errorOnProcess;
         }
-        return this._test.skip;
+        return this.test.skip;
     }
 
     get passed() {
@@ -45,7 +45,7 @@ exports.TestResult = class TestResult {
     set locale(locale) {
         this._locale = locale;
     }
-}
+};
 
 exports.InteractionResult = class InteractionResult {
     constructor(interaction, assertion, error, errorOnProcess, timestamp) {

--- a/test/JestAdapter.test.js
+++ b/test/JestAdapter.test.js
@@ -120,7 +120,7 @@ describe("JestAdapter", async () => {
 
         const testResult = new TestResult(test);
         const interaction = new TestInteraction("Hi");
-        const interactionResult = new InteractionResult(interaction)
+        const interactionResult = new InteractionResult(interaction);
         testResult.addInteractionResult(interactionResult);
 
         const testResult2 = new TestResult(test2);
@@ -129,7 +129,7 @@ describe("JestAdapter", async () => {
 
         const jestResults = await testRunner({}, {}, {}, new Runtime(results), "MyTest.yml");
         expect(jestResults.numPassingTests).toBe(0);
-        expect(jestResults.numFailingTests).toBe(1);
+        expect(jestResults.numFailingTests).toBe(0);
         expect(jestResults.numPendingTests).toBe(2);
         expect(jestResults.testResults[0].status).toBe("pending");
         expect(jestResults.testResults[1].status).toBe("pending");

--- a/test/JestAdapter.test.js
+++ b/test/JestAdapter.test.js
@@ -17,7 +17,7 @@ describe("JestAdapter", async () => {
         testResult.addInteractionResult(interactionResult);
 
         const interaction2 = new TestInteraction("Hi");
-        const interactionResult2 = new InteractionResult(interaction2)
+        const interactionResult2 = new InteractionResult(interaction2);
         testResult.addInteractionResult(interactionResult2);
 
         const results = [testResult];
@@ -29,7 +29,7 @@ describe("JestAdapter", async () => {
         expect(jestResults.testFilePath).toBe("MyTest.yml");
 
         // Check the individual test result
-        const jestTestResult = jestResults.testResults[0]
+        const jestTestResult = jestResults.testResults[0];
         expect(jestTestResult.ancestorTitles[0]).toBe("en-US");
         expect(jestTestResult.ancestorTitles[1]).toBe("Test Description");
         expect(jestTestResult.status).toBe("passed");
@@ -96,7 +96,7 @@ describe("JestAdapter", async () => {
 
         const testResult = new TestResult(test);
         const interaction = new TestInteraction("Hi");
-        const interactionResult = new InteractionResult(interaction)
+        const interactionResult = new InteractionResult(interaction);
         testResult.addInteractionResult(interactionResult);
 
         const testResult2 = new TestResult(test2);
@@ -130,6 +130,34 @@ describe("JestAdapter", async () => {
         const jestResults = await testRunner({}, {}, {}, new Runtime(results), "MyTest.yml");
         expect(jestResults.numPassingTests).toBe(0);
         expect(jestResults.numFailingTests).toBe(0);
+        expect(jestResults.numPendingTests).toBe(2);
+        expect(jestResults.skipped).toBe(true);
+        expect(jestResults.testResults[0].status).toBe("pending");
+        expect(jestResults.testResults[1].status).toBe("pending");
+    });
+
+    test("Runs a mock test that have only skips but have error messages", async () => {
+        const testSuite = new TestSuite("MyTest.yml");
+        const test = new Test(testSuite, { description: "Test 1" });
+        test.skip = true;
+        const test2 = new Test(testSuite, { description: "Test 2" });
+        test2.skip = true;
+
+        const testResult = new TestResult(test);
+        const interaction = new TestInteraction("Hi");
+        const interactionResult = new InteractionResult(interaction);
+        interactionResult._error = new Error("I am an error");
+        testResult.addInteractionResult(interactionResult);
+        testResult.locale = "en-US";
+
+        const testResult2 = new TestResult(test2);
+
+        const results = [testResult, testResult2];
+
+        const jestResults = await testRunner({}, { rootDir: "rootDir" }, {}, new Runtime(results), "MyTest.yml");
+        expect(jestResults.numPassingTests).toBe(0);
+        expect(jestResults.numFailingTests).toBe(1);
+        expect(jestResults.skipped).toBe(false);
         expect(jestResults.numPendingTests).toBe(2);
         expect(jestResults.testResults[0].status).toBe("pending");
         expect(jestResults.testResults[1].status).toBe("pending");


### PR DESCRIPTION
Relates to https://github.com/bespoken/bst/issues/537

Includes an exception to this rule for ignoreExternalErrors in which case we need to mark as failed in order to show the error that come back if everything in a testSuite ends being skipped.