### PR TITLE
Handle null messages

### DIFF
--- a/lib/util/SMAPI.js
+++ b/lib/util/SMAPI.js
@@ -93,7 +93,7 @@ module.exports = class SMAPI {
         const postResult = await simulation.post(command, newSession);
         debug("RESULT: " + JSON.stringify(postResult, null, 2));
         if (postResult.message || postResult.message === null) {
-            if ((postResult.message || null || postResult.message.includes("Token is invalid")) && this.askConfigured) {
+            if ((postResult.message === null || postResult.message.includes("Token is invalid")) && this.askConfigured) {
                 if (this.refreshFromCLI()) {
                     this.token = SMAPI.fetchAccessTokenFromConfig();
                     return this.simulate(command, newSession);

--- a/lib/util/SMAPI.js
+++ b/lib/util/SMAPI.js
@@ -92,8 +92,8 @@ module.exports = class SMAPI {
         debug("SMAPI COMMAND: " + command);
         const postResult = await simulation.post(command, newSession);
         debug("RESULT: " + JSON.stringify(postResult, null, 2));
-        if (postResult.message) {
-            if (postResult.message.includes("Token is invalid") && this.askConfigured) {
+        if (postResult.message || postResult.message === null) {
+            if ((postResult.message || null || postResult.message.includes("Token is invalid")) && this.askConfigured) {
                 if (this.refreshFromCLI()) {
                     this.token = SMAPI.fetchAccessTokenFromConfig();
                     return this.simulate(command, newSession);
@@ -103,9 +103,6 @@ module.exports = class SMAPI {
             } else {
                 throw new FrameworkError(postResult.message);
             }
-        } else if (postResult.message === null) {
-            // Seems like some times the message is null - correlates to a bad skill ID
-            throw new FrameworkError("Unspecified SMAPI error. Is the skillId set correctly?");
         }
 
         let getResult;


### PR DESCRIPTION
SMAPI stopped returning an invalid token message, at least temporarily. It now returns just null.

Hopefully, the original behavior will resume and we can take out this code.