### PR TITLE
Fix ugly error messages

### DIFF
--- a/lib/runner/SMAPIInvoker.js
+++ b/lib/runner/SMAPIInvoker.js
@@ -33,9 +33,8 @@ module.exports = class SMAPIInvoker extends invoker.Invoker {
         }
 
         if (!accessToken) {
-            throw new FrameworkError("To use SMAPI Simulate, either must:\n" 
-                + "1) supply Virtual Device Token (which has SMAPI permission)\n"
-                + "2) configure ASK CLI on the machine");
+            throw new FrameworkError("To use SMAPI Simulate, you must configure ASK CLI on the machine.\n" +
+                "The default profile will be used unless ASK_DEFAULT_PROFILE environment variable is set");
         }
         this.smapi = new SMAPI(accessToken, skillId, testSuite.locale, fromCLI);
     }

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -261,7 +261,7 @@ module.exports = class TestRunner {
             const message = Util.errorMessageWithLine(e.message, testSuite.fileName, interaction.lineNumber);
             return new InteractionResult(interaction, undefined, message);
         } else {
-            if (e instanceof FrameworkError) {
+            if (e.type && e.type === "FrameworkError") {
                 return new InteractionResult(interaction, undefined, e.message);
             } else if (e.message) {
                 return new InteractionResult(interaction, undefined, e.message + "\n" + e.stack);

--- a/lib/util/FrameworkError.js
+++ b/lib/util/FrameworkError.js
@@ -5,6 +5,8 @@
 module.exports = class FrameworkError extends Error {
     constructor(message) {
         super(message);
+        // For compatibility with older node versions, set a type variable we can check
+        this.type = "FrameworkError";
     }
 };
 	

--- a/lib/util/SMAPI.js
+++ b/lib/util/SMAPI.js
@@ -17,6 +17,12 @@ module.exports = class SMAPI {
         this.askConfigured = askConfigured;
     }
 
+    // Gets the name of the default profile for the ASK CLI
+    static defaultProfile() {
+        const profileName = process.env.ASK_DEFAULT_PROFILE ? process.env.ASK_DEFAULT_PROFILE : "default";
+        return profileName;    
+    }
+
     // Gets the SMAPI access token from the ASK config file
     static fetchAccessTokenFromConfig() {
         // Retrieves the access token - first tries getting it from the ASK CLI
@@ -25,7 +31,7 @@ module.exports = class SMAPI {
         if (fs.existsSync(cliConfigFile)) {
             const cliConfigString = fs.readFileSync(cliConfigFile);
             const cliConfig = JSON.parse(cliConfigString);
-            accessToken = cliConfig.profiles.default.token.access_token;
+            accessToken = _.get(cliConfig, "profiles." + SMAPI.defaultProfile() + ".token.access_token");
         } else {
             return undefined;
         }
@@ -62,7 +68,7 @@ module.exports = class SMAPI {
         if (fs.existsSync(projectConfigFile)) {
             const projectJSONString = fs.readFileSync(projectConfigFile);
             const projectJSON = JSON.parse(projectJSONString);
-            skillId = _.get(projectJSON, "deploy_settings.default.skill_id");
+            skillId = _.get(projectJSON, "deploy_settings." + SMAPI.defaultProfile() + ".skill_id");
         }
         return skillId;
     }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "preversion": "npm test && npm run test.babel",
     "test": "jest",
     "test.babel": "npm run babel && jest --config jest-config-babel.json",
-    "test.smapi": "jest --runInBand SMAPI.test",
+    "test.smapi": "jest --runInBand SMAPI",
     "coverage": "codecov",
     "test.watch": "jest --watchAll"
   },

--- a/test/SMAPI.test.js
+++ b/test/SMAPI.test.js
@@ -84,7 +84,8 @@ describeIf("SMAPI tests", () => {
     });
 
     test("Gets a non-default token when environment variable is set", () => {
-        // In order to run this test locally, need to set a "nonDefault" profile in .ask/cli_config
+        // In order to run this test locally, need to create a "nonDefault" profile in .ask/cli_config
+        // See the JSON above for what that should look like
         process.env.ASK_DEFAULT_PROFILE = "nonDefault";
         const token = SMAPI.fetchAccessTokenFromConfig();
         expect(token).toBe("TEST");

--- a/test/SMAPI.test.js
+++ b/test/SMAPI.test.js
@@ -46,6 +46,11 @@ describeIf("SMAPI tests", () => {
                     },
                     vendor_id: process.env.ASK_VENDOR_ID,
                 },
+                nonDefault: {
+                    token: {
+                        access_token: "TEST",
+                    },
+                },
             },
         };
 
@@ -76,6 +81,14 @@ describeIf("SMAPI tests", () => {
 				result.result.skillExecutionInfo.invocationResponse.body;
             expect(skillResponse.response.outputSpeech.ssml).toBe("Guess");
         }
+    });
+
+    test("Gets a non-default token when environment variable is set", () => {
+        // In order to run this test locally, need to set a "nonDefault" profile in .ask/cli_config
+        process.env.ASK_DEFAULT_PROFILE = "nonDefault";
+        const token = SMAPI.fetchAccessTokenFromConfig();
+        expect(token).toBe("TEST");
+        delete process.env.ASK_DEFAULT_PROFILE;
     });
 
     test.skip("simulate with access token", async () => {


### PR DESCRIPTION
- [X] Removes stack traces from GLOBAL (non-test specific) internally generated errors
- [X] If the ASK_DEFAULT_PROFILE variable is set, use that to lookup the accessToken