### PR TITLE
Add missing error logging on test runner

### DIFF
--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -272,6 +272,8 @@ module.exports = class TestRunner {
             const message = Util.errorMessageWithLine(e.message, testSuite.fileName, interaction.lineNumber);
             return new InteractionResult(interaction, undefined, message);
         } else {
+            LoggingErrorHelper.error("bst-test", "Error using bst-test on Node: " + process.version);
+            LoggingErrorHelper.error("bst-test", e.stack);
             if (e.type && e.type === "FrameworkError") {
                 return new InteractionResult(interaction, undefined, e.message);
             } else if (e.message) {


### PR DESCRIPTION
Relates to issue found on QA on https://github.com/bespoken/bst/issues/540