### PR TITLE
Use async process from virtual device in sequential mode for E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 *.tgz
 .vscode
 .env
+bst-debug.log

--- a/__mocks__/virtual-device-sdk.js
+++ b/__mocks__/virtual-device-sdk.js
@@ -6,17 +6,20 @@ const mockMessage = jest.fn((arg)=>{
 const mockAddHomophones = jest.fn();
 const mockWaitForSessionToEnd = jest.fn();
 
-const spaceFactMessage = jest.fn((messages)=> {
+const getResponsesFromMessages = (messages) => {
     const responses = [];
     for (const message of messages) {
         responses.push(handleMessage(message));
     }
     return responses;
-}) ;
+};
+
+const spaceFactMessage = jest.fn((messages)=> {
+    return getResponsesFromMessages(messages);
+});
 
 const mockGetConversationResults = jest.fn()
-    .mockReturnValueOnce([])
-    .mockReturnValue(spaceFactMessage([{ phrases: [], text: "Hi" },
+    .mockReturnValue(getResponsesFromMessages([{ phrases: [], text: "Hi" },
         { phrases: [ ".*Here's your fact*" ], text: "LaunchRequest" } ]));
 
 const mockVirtualDevice = jest.fn().mockImplementation((token) => {

--- a/__mocks__/virtual-device-sdk.js
+++ b/__mocks__/virtual-device-sdk.js
@@ -14,6 +14,11 @@ const spaceFactMessage = jest.fn((messages)=> {
     return responses;
 }) ;
 
+const mockGetConversationResults = jest.fn()
+    .mockReturnValueOnce([])
+    .mockReturnValue(spaceFactMessage([{ phrases: [], text: "Hi" },
+        { phrases: [ ".*Here's your fact*" ], text: "LaunchRequest" } ]));
+
 const mockVirtualDevice = jest.fn().mockImplementation((token) => {
     if(token === "space fact") return {batchMessage: spaceFactMessage};
     if(token === "async token") return {
@@ -22,10 +27,7 @@ const mockVirtualDevice = jest.fn().mockImplementation((token) => {
                 conversation_id: "dummy-id",
             };
         }),
-        getConversationResults: jest.fn()
-            .mockReturnValueOnce([])
-            .mockReturnValue(spaceFactMessage([{ phrases: [], text: "Hi" },
-                { phrases: [ ".*Here's your fact*" ], text: "LaunchRequest" } ])),
+        getConversationResults: mockGetConversationResults,
     };
     return {
         addHomophones: mockAddHomophones,
@@ -126,5 +128,6 @@ function handleMessage(message) {
 exports.spaceFactMessage = spaceFactMessage;
 exports.mockMessage = mockMessage;
 exports.mockAddHomophones = mockAddHomophones;
+exports.mockGetConversationResults = mockGetConversationResults;
 exports.mockVirtualDevice = mockVirtualDevice;
 exports.VirtualDevice = mockVirtualDevice;

--- a/__mocks__/virtual-device-sdk.js
+++ b/__mocks__/virtual-device-sdk.js
@@ -12,14 +12,25 @@ const spaceFactMessage = jest.fn((messages)=> {
         responses.push(handleMessage(message));
     }
     return responses;
-});
+}) ;
 
 const mockVirtualDevice = jest.fn().mockImplementation((token) => {
     if(token === "space fact") return {batchMessage: spaceFactMessage};
+    if(token === "async token") return {
+        batchMessage: jest.fn(() => {
+            return {
+                conversation_id: "dummy-id",
+            };
+        }),
+        getConversationResults: jest.fn()
+            .mockReturnValueOnce([])
+            .mockReturnValue(spaceFactMessage([{ phrases: [], text: "Hi" },
+                { phrases: [ ".*Here's your fact*" ], text: "LaunchRequest" } ])),
+    };
     return {
         addHomophones: mockAddHomophones,
         batchMessage: mockMessage,
-        waitForSessionToEnd: mockWaitForSessionToEnd
+        waitForSessionToEnd: mockWaitForSessionToEnd,
     };
 });
 
@@ -43,7 +54,7 @@ function handleMessage(message) {
                 }, {
                     url: "this is a url 2"
                 }
-            ]            
+            ]
         },
         raw: {
             key: "some value",

--- a/__mocks__/virtual-device-sdk.js
+++ b/__mocks__/virtual-device-sdk.js
@@ -32,6 +32,12 @@ const mockVirtualDevice = jest.fn().mockImplementation((token) => {
         }),
         getConversationResults: mockGetConversationResults,
     };
+    if(token === "async token throws") return {
+        batchMessage: jest.fn(() => {
+            throw new Error("Network Error");
+        }),
+        getConversationResults: mockGetConversationResults,
+    };
     return {
         addHomophones: mockAddHomophones,
         batchMessage: mockMessage,

--- a/lib/runner/ConfigurationKeys.js
+++ b/lib/runner/ConfigurationKeys.js
@@ -8,6 +8,10 @@ const ConfigurationKeys = [
         text: "set skill URL",
     },
     {
+        key: "asyncE2EWaitInterval",
+        text: "set how much time e2e waits to check for processed messages in ms, defaults to 5000",
+    },
+    {
         key: "actionURL",
         text: "set action URL",
     },
@@ -54,6 +58,10 @@ const ConfigurationKeys = [
     {
         key: "exclude",
         text: "don't run the indicated tags",
+    },
+    {
+        key: "maxAsyncE2EResponseWaitTime",
+        text: "set the max time we wait for a single response in a e2e async interaction in ms, defaults to 15000",
     },
     {
         key: "reporters",

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -156,6 +156,7 @@ module.exports = class TestRunner {
             try {
                 response = await invoker.invoke(interaction, interactions);
             } catch (e) {
+
                 const resultOnException = this.handleException(interaction, e);
                 results.push(resultOnException);
                 const interactionDto = interaction.toDTO();

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -154,7 +154,7 @@ module.exports = class TestRunner {
             this.emit("message", undefined, interaction.toDTO(), context);
             let response;
             try {
-                response = await invoker.invoke(interaction);
+                response = await invoker.invoke(interaction, interactions);
             } catch (e) {
                 const resultOnException = this.handleException(interaction, e);
                 results.push(resultOnException);

--- a/lib/runner/VirtualDeviceInvoker.js
+++ b/lib/runner/VirtualDeviceInvoker.js
@@ -34,8 +34,8 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
         const virtualDeviceToken = testSuite.virtualDeviceToken;
         const virtualDeviceAsyncMode = !testSuite.batchEnabled;
 
-        maxResponseWaitTime = testSuite.maxResponseWaitTime || 15000;
-        waitInterval = testSuite.waitInterval  || 5000;
+        maxResponseWaitTime = testSuite.maxAsyncE2EResponseWaitTime;
+        waitInterval = testSuite.asyncE2EWaitInterval;
 
         // virtualDeviceAsyncMode = testSuite.virtualDeviceAsyncMode || undefined;
         if (!virtualDeviceToken) {
@@ -136,12 +136,11 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
         if (!interaction.utterance) {
             return;
         }
-
         const { messages, messageInteractions } = this.convertInteractionsToMessages(interactions);
         let asyncBatchResult;
 
         let errorOnProcess = undefined;
-        let rawVirtualDeviceResponse = undefined;
+        let rawVirtualDeviceResponse;
         let totalTimeWaited = 0;
         try {
             const interactionIndex = messageInteractions.findIndex((messageInteraction) => {
@@ -163,7 +162,6 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
                 // one response in the same result
                 const processedInteractions =
                     await this._virtualDevice.getConversationResults(this.currentConversation);
-
                 if (processedInteractions.length) {
                     if (processedInteractions[interactionIndex]) {
                         // We have reached the interaction that we have at the moment
@@ -182,16 +180,19 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
                 }
             } while(!rawVirtualDeviceResponse && !isCurrentInteractionTimeoutExceed);
 
+            if (isCurrentInteractionTimeoutExceed) {
+                throw new FrameworkError("Timeout exceeded while waiting for the interaction response");
+            }
 
         } catch (error) {
             const parsedError = this.parseError(error);
             if (parsedError && parsedError.results) {
-                asyncBatchResult = parsedError.results;
+                rawVirtualDeviceResponse = parsedError.results;
             } else {
                 debug("Error: " + JSON.stringify(error));
                 LoggingErrorHelper.error("bst-test", "Error using bst-test on Node: " + process.version);
                 LoggingErrorHelper.error("bst-test", error.stack);
-                asyncBatchResult.fill({});
+
                 errorOnProcess = this.getError(error);
             }
         }

--- a/lib/runner/VirtualDeviceInvoker.js
+++ b/lib/runner/VirtualDeviceInvoker.js
@@ -5,11 +5,23 @@ const FrameworkError = require("../util/FrameworkError");
 const Invoker = require("./Invoker").Invoker;
 const InvokerResponse = require("./Invoker").InvokerResponse;
 const LoggingErrorHelper = require("../util/LoggingErrorHelper");
+const sleep = require("../util/Util").sleep;
 const VirtualDevice = require("virtual-device-sdk").VirtualDevice;
+
+let maxResponseWaitTime;
+let waitInterval;
 
 module.exports = class VirtualDeviceInvoker extends Invoker {
     constructor(runner) {
         super(runner);
+    }
+
+    get currentConversation() {
+        return this._currentConversation;
+    }
+
+    set currentConversation(currentConversation) {
+        this._currentConversation = currentConversation;
     }
 
     batchSupported() {
@@ -20,11 +32,17 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
         const locale = testSuite.locale || undefined;
         const voiceId = testSuite.voiceId || undefined;
         const virtualDeviceToken = testSuite.virtualDeviceToken;
+        const virtualDeviceAsyncMode = !testSuite.batchEnabled;
+
+        maxResponseWaitTime = testSuite.maxResponseWaitTime || 15000;
+        waitInterval = testSuite.waitInterval  || 5000;
+
+        // virtualDeviceAsyncMode = testSuite.virtualDeviceAsyncMode || undefined;
         if (!virtualDeviceToken) {
             throw new FrameworkError("A valid virtualDeviceToken property must be defined either in the testing.json or the yml test file under the config element");
         }
 
-        this._virtualDevice = new VirtualDevice(virtualDeviceToken, locale, voiceId);
+        this._virtualDevice = new VirtualDevice(virtualDeviceToken, locale, voiceId, undefined, virtualDeviceAsyncMode);
 
         const homophones = testSuite.homophones;
         if (homophones) {
@@ -35,7 +53,7 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
         }
     }
 
-    async invokeBatch(interactions) {
+    convertInteractionsToMessages(interactions) {
         const messages = [];
 
         // Keep an array of the actual interactions sent, as some may be skipped
@@ -57,7 +75,7 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
                     // If this is a check on the prompt or the transcript
                     //  we add the expected value as a phrase - this helps with speech recognition
                     if ((assertion.path === "prompt" ||
-                        assertion.path === "transcript")
+                            assertion.path === "transcript")
                         && (assertion.operator === "==" ||
                             assertion.operator === "=~")) {
                         // Need to check if this is an array - the prompt assertions can specify a collection of strings
@@ -73,6 +91,11 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
 
             messages.push(message);
         }
+        return { messageInteractions, messages};
+    }
+
+    async invokeBatch(interactions) {
+        const { messages, messageInteractions } = this.convertInteractionsToMessages(interactions);
 
         let results = new Array(messages.length);
         let errorOnProcess = undefined;
@@ -109,50 +132,70 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
         return responses;
     }
 
-    async invoke(interaction) {
+    async invoke(interaction, interactions) {
         if (!interaction.utterance) {
             return;
         }
 
-        const message = {
-            phrases: [],
-            text: interaction.utterance,
-        };
+        const { messages, messageInteractions } = this.convertInteractionsToMessages(interactions);
+        let asyncBatchResult;
 
-        if (interaction.assertions) {
-            for (const assertion of interaction.assertions) {
-                // If this is a check on the prompt or the transcript
-                //  we add the expected value as a phrase - this helps with speech recognition
-                if ((assertion.path === "prompt" ||
-                        assertion.path === "transcript")
-                    && (assertion.operator === "==" ||
-                        assertion.operator === "=~")) {
-                    // Need to check if this is an array - the prompt assertions can specify a collection of strings
-                    if (Array.isArray(assertion.value)) {
-                        message.phrases = message.phrases.concat(assertion.value);
-                    } else {
-                        message.phrases.push(assertion.value);
-                    }
-
-                }
-            }
-        }
-
-        let results = new Array(1);
         let errorOnProcess = undefined;
+        let rawVirtualDeviceResponse = undefined;
+        let totalTimeWaited = 0;
         try {
-            results = await this._virtualDevice.batchMessage([message], false);
+            const interactionIndex = messageInteractions.findIndex((messageInteraction) => {
+                return messageInteraction.lineNumber === interaction.lineNumber;
+            });
+
+            // This is the first interaction, we send the whole list of interactions and get the conversation id
+            if (interactionIndex === 0) {
+                asyncBatchResult = await this._virtualDevice.batchMessage(messages, false);
+
+                this.currentConversation = asyncBatchResult.conversation_id;
+            }
+
+            // We query every 5 seconds to see if we got the current interaction results
+            let isCurrentInteractionTimeoutExceed = false;
+            do {
+                // we query first before waiting because after the first interaction this ensure to get the responses
+                // as soon as we can to the user, instead of adding 5 obligatory seconds every time if we got more than
+                // one response in the same result
+                const processedInteractions =
+                    await this._virtualDevice.getConversationResults(this.currentConversation);
+
+                if (processedInteractions.length) {
+                    if (processedInteractions[interactionIndex]) {
+                        // We have reached the interaction that we have at the moment
+
+                        rawVirtualDeviceResponse = processedInteractions[interactionIndex];
+                    }
+                }
+
+                if (totalTimeWaited >= maxResponseWaitTime) {
+                    isCurrentInteractionTimeoutExceed = true;
+                }
+
+                if (!isCurrentInteractionTimeoutExceed && !rawVirtualDeviceResponse) {
+                    await sleep(waitInterval);
+                    totalTimeWaited+= waitInterval;
+                }
+            } while(!rawVirtualDeviceResponse && !isCurrentInteractionTimeoutExceed);
+
+
         } catch (error) {
             const parsedError = this.parseError(error);
             if (parsedError && parsedError.results) {
-                results = parsedError.results;
+                asyncBatchResult = parsedError.results;
             } else {
                 debug("Error: " + JSON.stringify(error));
-                results.fill({});
+                LoggingErrorHelper.error("bst-test", "Error using bst-test on Node: " + process.version);
+                LoggingErrorHelper.error("bst-test", error.stack);
+                asyncBatchResult.fill({});
                 errorOnProcess = this.getError(error);
             }
         }
-        const virtualDeviceResponse = new VirtualDeviceResponse(interaction, results[0]);
+        const virtualDeviceResponse = new VirtualDeviceResponse(interaction, rawVirtualDeviceResponse);
         if (errorOnProcess) {
             virtualDeviceResponse.errorOnProcess = errorOnProcess;
             return virtualDeviceResponse;

--- a/lib/runner/VirtualDeviceInvoker.js
+++ b/lib/runner/VirtualDeviceInvoker.js
@@ -162,6 +162,7 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
                 // one response in the same result
                 const processedInteractions =
                     await this._virtualDevice.getConversationResults(this.currentConversation);
+
                 if (processedInteractions.length) {
                     if (processedInteractions[interactionIndex]) {
                         // We have reached the interaction that we have at the moment
@@ -181,7 +182,7 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
             } while(!rawVirtualDeviceResponse && !isCurrentInteractionTimeoutExceed);
 
             if (isCurrentInteractionTimeoutExceed) {
-                throw new FrameworkError("Timeout exceeded while waiting for the interaction response");
+                errorOnProcess = "Timeout exceeded while waiting for the interaction response";
             }
 
         } catch (error) {
@@ -222,6 +223,8 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
                 } else if (Array.isArray(objectError.error)) {
                     return objectError.error.join(", ");
                 }
+            } else if (objectError.message) {
+                return objectError.message;
             }
             return "Error description missing.";
         }

--- a/lib/runner/VirtualDeviceInvoker.js
+++ b/lib/runner/VirtualDeviceInvoker.js
@@ -37,7 +37,6 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
         maxResponseWaitTime = testSuite.maxAsyncE2EResponseWaitTime;
         waitInterval = testSuite.asyncE2EWaitInterval;
 
-        // virtualDeviceAsyncMode = testSuite.virtualDeviceAsyncMode || undefined;
         if (!virtualDeviceToken) {
             throw new FrameworkError("A valid virtualDeviceToken property must be defined either in the testing.json or the yml test file under the config element");
         }
@@ -160,6 +159,7 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
                 // we query first before waiting because after the first interaction this ensure to get the responses
                 // as soon as we can to the user, instead of adding 5 obligatory seconds every time if we got more than
                 // one response in the same result
+
                 const processedInteractions =
                     await this._virtualDevice.getConversationResults(this.currentConversation);
 

--- a/lib/runner/VirtualDeviceInvoker.js
+++ b/lib/runner/VirtualDeviceInvoker.js
@@ -147,7 +147,7 @@ module.exports = class VirtualDeviceInvoker extends Invoker {
             });
 
             // This is the first interaction, we send the whole list of interactions and get the conversation id
-            if (interactionIndex === 0) {
+            if (interactionIndex === 0 || !this.currentConversation) {
                 asyncBatchResult = await this._virtualDevice.batchMessage(messages, false);
 
                 this.currentConversation = asyncBatchResult.conversation_id;

--- a/lib/test/TestSuite.js
+++ b/lib/test/TestSuite.js
@@ -71,6 +71,10 @@ module.exports = class TestSuite {
         return Configuration.instance().value("applicationId", this.configuration);
     }
 
+    get asyncE2EWaitInterval() {
+        return Configuration.instance().value("asyncE2EWaitInterval", this.configuration, 5000);
+    }
+
     get configuration() {
         return this._configuration;
     }
@@ -244,6 +248,10 @@ module.exports = class TestSuite {
 
     get ignoreProperties() {
         return Configuration.instance().value("ignoreProperties", this.configuration, {});
+    }
+
+    get maxAsyncE2EResponseWaitTime() {
+        return Configuration.instance().value("maxAsyncE2EResponseWaitTime", this.configuration, 15000);
     }
 
     getLocalizedValue(key) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-testing-ml",
-  "version": "0.8.4",
+  "version": "0.8.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -814,9 +814,9 @@
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
     },
     "aws-sdk": {
-      "version": "2.409.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.409.0.tgz",
-      "integrity": "sha512-QV6j9zBQq/Kz8BqVOrJ03ABjMKtErXdUT1YdYEljoLQZimpzt0ZdQwJAsoZIsxxriOJgrqeZsQUklv9AFQaldQ==",
+      "version": "2.423.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.423.0.tgz",
+      "integrity": "sha512-BgsqrCMeJuE+gyWbqzDXvwzdEOyl5f9VIy0tgh78vqPI/09j9s4TKC9McMr6I4uTifVUpOxxultPS39PcTjQeA==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -1681,6 +1681,7 @@
               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "remove-trailing-separator": "^1.0.1"
               }
@@ -1783,6 +1784,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -1796,10 +1806,33 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+    },
     "colors": {
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
       "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+    },
+    "colorspace": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
+      "integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "colour": {
       "version": "0.7.1",
@@ -2136,6 +2169,16 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
     },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -2281,6 +2324,14 @@
         "core-js": "^2.0.0"
       }
     },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -2301,6 +2352,11 @@
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
+    },
+    "env-variable": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
     },
     "error-ex": {
       "version": "1.3.1",
@@ -3843,6 +3899,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+    },
     "faye-websocket": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
@@ -3859,6 +3920,11 @@
       "requires": {
         "bser": "^2.0.0"
       }
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -6896,6 +6962,14 @@
         "is-buffer": "^1.1.5"
       }
     },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "requires": {
+        "colornames": "^1.1.1"
+      }
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -7021,6 +7095,30 @@
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
+    },
+    "logform": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+      "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
     },
     "long": {
       "version": "4.0.0",
@@ -7779,6 +7877,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
     "optimist": {
       "version": "0.6.1",
@@ -8719,6 +8822,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -8970,6 +9088,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
@@ -9181,6 +9304,11 @@
         }
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -9317,6 +9445,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tslib": {
       "version": "1.9.0",
@@ -9612,9 +9745,9 @@
       }
     },
     "virtual-alexa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/virtual-alexa/-/virtual-alexa-0.7.0.tgz",
-      "integrity": "sha512-YuaQFjZqhKvO1ngxin//q/I947xCLU8RsOl+zkj76KDARvqYoRhZXGS98kqr0wDWuqWIxCRDqUEch6C/9m8dAA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/virtual-alexa/-/virtual-alexa-0.7.2.tgz",
+      "integrity": "sha512-/Lepl87U2YKgH9NWFffPdqWM19Qx+QKb3MOnZ82jM8/0GxEtHmbItEd9c+GS+TVL5+FubD2ZsGetPl1svQGICQ==",
       "requires": {
         "aws-sdk": "^2.402.0",
         "lodash": "^4.17.11",
@@ -9623,11 +9756,6 @@
         "virtual-core": "0.0.12"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        },
         "nock": {
           "version": "9.6.1",
           "resolved": "https://registry.npmjs.org/nock/-/nock-9.6.1.tgz",
@@ -9661,9 +9789,9 @@
       }
     },
     "virtual-device-sdk": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/virtual-device-sdk/-/virtual-device-sdk-1.5.3.tgz",
-      "integrity": "sha512-5S589jBCYSwkxGdUp6r0b53Q745ghcKBfepm5pkOZtVP2nWCLtdQReZQnQCmFz8T3+OUxjCSJYb0mgfYIR/aUQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/virtual-device-sdk/-/virtual-device-sdk-1.5.10.tgz",
+      "integrity": "sha512-o2R+cRBerKh068u2WcQBc5DJOaFqoCKGDe1yH8y2NlygtKJyGsx678SB6BGEfLQjlAb2N6nEyc+qNrOQrsoWog==",
       "requires": {
         "chalk": "^2.3.1",
         "dotenv": "^4.0.0"
@@ -9671,7 +9799,7 @@
       "dependencies": {
         "dotenv": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
           "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
         }
       }
@@ -9801,6 +9929,51 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "requires": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "readable-stream": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+      "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+      "requires": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
+      }
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "jsonpath-bespoken": "^1.0.1",
     "lodash": "^4.17.11",
     "virtual-alexa": "^0.7.0",
-    "virtual-device-sdk": "^1.5.1",
+    "virtual-device-sdk": "^1.5.9",
     "virtual-google-assistant": "0.3.0",
     "winston": "^3.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "js-yaml-bespoken": "^3.11.5",
     "jsonpath-bespoken": "^1.0.1",
     "lodash": "^4.17.11",
-    "virtual-alexa": "^0.7.0",
-    "virtual-device-sdk": "^1.5.9",
+    "virtual-alexa": "^0.7.2",
+    "virtual-device-sdk": "^1.5.10",
     "virtual-google-assistant": "0.3.0",
     "winston": "^3.2.1"
   },

--- a/test/VirtualDeviceInvoker.test.js
+++ b/test/VirtualDeviceInvoker.test.js
@@ -244,6 +244,9 @@ describe("virtual device runner", () => {
     describe("virtual device async mode", () => {
         beforeAll(() => {
             loggerSpy = jest.spyOn(LoggingErrorHelper, "error").mockImplementation(() => {});
+        });
+
+        beforeEach(() => {
             Configuration.reset();
             return Configuration.configure({
                 asyncE2EWaitInterval: 1,
@@ -285,6 +288,30 @@ describe("virtual device runner", () => {
             expect(results[0].interactionResults[1].errorOnProcess).toBeDefined();
             expect(results[0].interactionResults[1].errorOnProcess).toBe(
                 "Timeout exceeded while waiting for the interaction response");
+        });
+
+        test("Test flow with async when getting conversation id throws an exception", async () => {
+            Configuration.reset();
+            Configuration.configure({
+                asyncE2EWaitInterval: 1,
+                batchEnabled: false,
+                invocationName: "space fact",
+                locale: "en-US",
+                maxAsyncE2EResponseWaitTime: 3,
+                type: CONSTANTS.TYPE.e2e,
+                virtualDeviceToken: "async token throws",
+            });
+            const runner = new TestRunner();
+            mockGetConversationResults.mockReturnValue([]);
+
+            const results = await runner.run("test/FactSkill/fact-skill-tests.common.yml");
+
+            expect(results.length).toEqual(3);
+            expect(results[0].test.description).toEqual("Launches successfully");
+
+            expect(results[0].interactionResults.length).toBe(2);
+            expect(results[0].interactionResults[1].errorOnProcess).toBeDefined();
+            expect(results[0].interactionResults[1].errorOnProcess).toBe("Network Error");
         });
 
         test("Test flow with async when there's an exception", async () => {

--- a/test/VirtualDeviceInvoker.test.js
+++ b/test/VirtualDeviceInvoker.test.js
@@ -273,6 +273,34 @@ describe("virtual device runner", () => {
         });
     });
 
+    describe("virtual device async mode", () => {
+        beforeAll(() => {
+            loggerSpy = jest.spyOn(LoggingErrorHelper, "error").mockImplementation(() => {});
+            Configuration.reset();
+            return Configuration.configure({
+                batchEnabled: false,
+                invocationName: "space fact",
+                locale: "en-US",
+                maxResponseWaitTime: 4,
+                type: CONSTANTS.TYPE.e2e,
+                virtualDeviceToken: "async token",
+                waitInterval: 1,
+            });
+        });
+
+        test("Test flow with async", async () => {
+            const runner = new TestRunner();
+
+            const results = await runner.run("test/FactSkill/fact-skill-tests.common.yml");
+
+            expect(results.length).toEqual(3);
+            expect(results[0].test.description).toEqual("Launches successfully");
+            expect(results[0].interactionResults[0].interaction.utterance).toEqual("Hi");
+            expect(results[0].interactionResults[1].error).toBeUndefined();
+
+        }, 15000);
+    });
+
     describe("edge case tests", () => {
         beforeAll(() => {
             loggerSpy = jest.spyOn(LoggingErrorHelper, "error").mockImplementation(() => {});

--- a/test/VirtualDeviceInvoker.test.js
+++ b/test/VirtualDeviceInvoker.test.js
@@ -241,40 +241,6 @@ describe("virtual device runner", () => {
 
     });
 
-
-    describe("control flow tests", () => {
-        beforeAll(() => {
-            loggerSpy = jest.spyOn(LoggingErrorHelper, "error").mockImplementation(() => {});
-
-            return Configuration.configure({
-                invocationName: "space fact",
-                locale: "en-US",
-                type: CONSTANTS.TYPE.e2e,
-                // eslint-disable-next-line spellcheck/spell-checker
-                virtualDeviceToken: "space fact",
-            });
-        });
-
-        test("Test goto", async () => {
-            const runner = new TestRunner();
-
-            const results = await runner.run("test/TestFiles/control-flow-tests.common.yml");
-            expect(results.length).toEqual(2);
-            expect(results[0].interactionResults.length).toBe(2);
-            expect(results[0].interactionResults[0].passed).toBe(true);
-            expect(results[0].interactionResults[0].goto).toBe("Get New Fact");
-            expect(results[0].interactionResults[0].error).toBeUndefined();
-            expect(results[0].interactionResults[1].interaction.utterance).toBe("Get New Fact");
-            expect(results[0].interactionResults[1].passed).toBe(false);
-
-            // Check on exit
-            expect(results[1].interactionResults.length).toBe(1);
-            expect(results[1].interactionResults[0].passed).toBe(true);
-            expect(results[1].interactionResults[0].error).toBeUndefined();
-            expect(results[1].interactionResults[0].exited).toBe(true);
-        });
-    });
-
     describe("virtual device async mode", () => {
         beforeAll(() => {
             loggerSpy = jest.spyOn(LoggingErrorHelper, "error").mockImplementation(() => {});
@@ -350,6 +316,10 @@ describe("virtual device runner", () => {
             });
         });
 
+        afterEach(() => {
+            loggerSpy.mockRestore();
+        });
+
         test("no response", async () => {
             const runner = new TestRunner();
 
@@ -406,11 +376,8 @@ describe("virtual device runner", () => {
                 virtualDeviceToken: "space fact",
             });
             const runner = new TestRunner();
-
             const results = await runner.run("test/FactSkill/fact-skill-throw-error.yml");
             expect(results.length).toEqual(4);
-            // twice for each error
-            expect(loggerSpy).toHaveBeenCalledTimes(4);
 
             expect(results[0].skipped).toBe(false);
             expect(results[0].interactionResults.length).toBe(2);

--- a/test/VirtualDeviceInvoker.test.js
+++ b/test/VirtualDeviceInvoker.test.js
@@ -278,13 +278,13 @@ describe("virtual device runner", () => {
             loggerSpy = jest.spyOn(LoggingErrorHelper, "error").mockImplementation(() => {});
             Configuration.reset();
             return Configuration.configure({
+                asyncE2EWaitInterval: 1,
                 batchEnabled: false,
                 invocationName: "space fact",
                 locale: "en-US",
-                maxResponseWaitTime: 4,
+                maxAsyncE2EResponseWaitTime: 4,
                 type: CONSTANTS.TYPE.e2e,
                 virtualDeviceToken: "async token",
-                waitInterval: 1,
             });
         });
 
@@ -298,7 +298,7 @@ describe("virtual device runner", () => {
             expect(results[0].interactionResults[0].interaction.utterance).toEqual("Hi");
             expect(results[0].interactionResults[1].error).toBeUndefined();
 
-        }, 15000);
+        });
     });
 
     describe("edge case tests", () => {


### PR DESCRIPTION
Relates to #147
- Set the async process when batchEnabled is false
- Set two configuration variables to control how much time we wait before querying the conversations, and how much time we wait before sending a timeout error
- update the mocks and tests to reflect the changes

- This change **doesn't make** test interactions appear one by one since we sent to jest the results of a whole test.