### PR TITLE
Always use --env even if .env is on root

### DIFF
--- a/lib/Index.js
+++ b/lib/Index.js
@@ -1,5 +1,3 @@
-require("dotenv").config();
-
 exports.CLI = require("./runner/CLI");
 exports.TestRunner = require("./runner/TestRunner");
 exports.TestParser = require("./test/TestParser");

--- a/lib/runner/CLI.js
+++ b/lib/runner/CLI.js
@@ -43,6 +43,8 @@ class CLI {
         configurationOverrides["runId"] = uuid();
         if (configurationOverrides.env) {
             Configuration.changeEnvironmentFileLocation(configurationOverrides.env);
+        } else {
+            require("dotenv").config();
         }
 
         await Configuration.configure(undefined, testPath, configurationOverrides);

--- a/lib/util/HTTP.js
+++ b/lib/util/HTTP.js
@@ -1,9 +1,6 @@
-const dotenv = require("dotenv");
 const http = require("http");
 const https = require("https");
 const HttpsProxyAgent = require("https-proxy-agent");
-
-dotenv.config();
 
 module.exports = class HTTP {
     static async get(options) {


### PR DESCRIPTION
Relates to https://github.com/bespoken/bst/issues/637
- Remove .env setting on construction
- Delay calling .env until we know if a path is setup
