### PR TITLE
IVR default values

### DIFF
--- a/lib/test/TestSuite.js
+++ b/lib/test/TestSuite.js
@@ -166,7 +166,8 @@ class TestSuite {
      * @return {boolean} the async mode flag
      */
     get asyncMode() {
-        return this.batchEnabled && Configuration.instance().value("asyncMode", this.configuration, false);
+        const defaultValue = ["twilio", "sms"].includes(this.platform) ? true : false;
+        return this.batchEnabled && Configuration.instance().value("asyncMode", this.configuration, defaultValue);
     }
 
     /**
@@ -501,7 +502,7 @@ class TestSuite {
      * @return {number} max wait time for a single utterance
      */
     get maxAsyncE2EResponseWaitTime() {
-        const defaultValue = this.platform === "twilio" ? 60000 : 15000;
+        const defaultValue = ["twilio", "sms"].includes(this.platform) ? 60000 : 15000;
         return Configuration.instance().value("maxAsyncE2EResponseWaitTime", this.configuration, defaultValue);
     }
 


### PR DESCRIPTION
Set `maxAsyncE2EResponseWaitTime` and `asyncMode` values to `60000` and `true` by default for twilio and sms platforms
Related to https://github.com/bespoken/ivr-server/issues/69