### PR TITLE
Creating new function to push test results after executed with bst CLI

### DIFF
--- a/lib/runner/CLI.js
+++ b/lib/runner/CLI.js
@@ -6,6 +6,7 @@ const jestModule = require("jest");
 const LoggingErrorHelper = require("../util/LoggingErrorHelper");
 const path = require("path");
 const uuid = require("uuid/v4");
+const { ResultsPublisher } = require("../runner/ResultsPublisher");
 
 const Logger = "bst-test";
 
@@ -64,20 +65,18 @@ class CLI {
             || invoker === CONSTANTS.INVOKER.virtualDeviceInvoker
             || invoker === CONSTANTS.INVOKER.SMAPIInvoker;
 
-        if (isRunningRemote){
+        if (isRunningRemote) {
             jestConfig.collectCoverage = false;
         }
 
         jestConfig.globals = { overrides: configurationOverrides };
         debug("JEST Config: " + JSON.stringify(jestConfig));
 
+        const config = JSON.stringify(jestConfig);
         // Call Jest via API so we can stay in-process
-        const returnValue = await jestModule.runCLI({ 
-            config: JSON.stringify(jestConfig), 
-            runInBand,
-        }, [process.cwd()]);
-        const success = returnValue.results ? returnValue.results.success : false;
-        return success;
+        return jestModule.runCLI({ config, runInBand }, [process.cwd()])
+            .then(jestResult => new ResultsPublisher().publishResults(jestResult).then(() => jestResult))
+            .then(jestResult => jestResult.results ? jestResult.results.success : false);
     }
 
     printVersion() {

--- a/lib/runner/JestAdapter.js
+++ b/lib/runner/JestAdapter.js
@@ -20,15 +20,26 @@ module.exports = async function testRunner(globalConfig, config, environment, ru
     await Configuration.configure(undefined, undefined, _.get(config, "globals.overrides"));
     const runner = new TestRunner(Configuration.instance().skillTestingConfig());
 
+    const bespokenExtensions = { bespokenResults: null };
     let jestResults;
     let passing = 0;
     let failing = 0;
     let pending = 0;
-
     let doResultsHaveErrorMessages = false;
 
     try {
         const results = await runner.run(testPath);
+
+        bespokenExtensions.bespokenResults = Util.cloneWithoutCircularReference(
+            results.map((e) => {
+                // clone some circular dependencies attributes before dropping them
+                _.set(e, "_test", _.cloneDeep(e._test));
+                _.set(e, "_test._testSuite", _.omit(_.cloneDeep(e._test._testSuite), ["tests"]));
+                _.set(e, "_test._testSuite._configuration", _.cloneDeep(e._test._testSuite._configuration));
+                return e;
+            })
+        );
+
         jestResults = transformResults(results);
 
         // Summarize the results
@@ -58,7 +69,7 @@ module.exports = async function testRunner(globalConfig, config, environment, ru
         testPath,
     );
 
-    return {
+    return _.assign({
         console: null,
         displayName: "Display name",
         failureMessage,
@@ -82,7 +93,7 @@ module.exports = async function testRunner(globalConfig, config, environment, ru
         testExecError: undefined,
         testFilePath: testPath,
         testResults: jestResults,
-    };
+    }, bespokenExtensions);
 };
 
 function transformResults(results) {
@@ -119,7 +130,7 @@ function addTimestampToError(errorMessage, timestamp) {
     return error;
 }
 
-function getError(error){
+function getError(error) {
     let objectError = undefined;
     try {
         objectError = JSON.parse(error);
@@ -127,11 +138,11 @@ function getError(error){
         objectError = error;
     }
 
-    if (typeof(objectError) === "string") {
+    if (typeof (objectError) === "string") {
         return objectError;
-    } else if (typeof(objectError) === "object") {
+    } else if (typeof (objectError) === "object") {
         if (objectError.error) {
-            if (typeof(objectError.error) === "string") {
+            if (typeof (objectError.error) === "string") {
                 return objectError.error;
             } else if (Array.isArray(objectError.error)) {
                 return objectError.error.join(", ");

--- a/lib/runner/JestAdapter.js
+++ b/lib/runner/JestAdapter.js
@@ -31,7 +31,7 @@ module.exports = async function testRunner(globalConfig, config, environment, ru
         const results = await runner.run(testPath);
 
         bespokenExtensions.bespokenResults = Util.cloneWithoutCircularReference(
-            results.map((e) => {
+            _.cloneDeep(results).map((e) => {
                 // clone some circular dependencies attributes before dropping them
                 _.set(e, "_test", _.cloneDeep(e._test));
                 _.set(e, "_test._testSuite", _.omit(_.cloneDeep(e._test._testSuite), ["tests"]));

--- a/lib/runner/ResultsPublisher.js
+++ b/lib/runner/ResultsPublisher.js
@@ -143,7 +143,7 @@ const transformIntoPayload = (data) => {
 };
 
 const postDataIntoEndpoint = async (payload,
-    baseUrl = process.env.SOURCE_API_BASE_URL || "https://bespoken-api.bespoken.tools",
+    baseUrl = process.env.BESPOKEN_API_BASE_URL || "https://bespoken-api.bespoken.tools",
     method = "POST",
     headers = { "Content-Type": "application/json" }) => {
     // eslint-disable-next-line

--- a/lib/runner/ResultsPublisher.js
+++ b/lib/runner/ResultsPublisher.js
@@ -142,12 +142,15 @@ const transformIntoPayload = (data) => {
     };
 };
 
-const postDataIntoEndpoint = async (payload,
-    baseUrl = process.env.BESPOKEN_API_BASE_URL || "https://bespoken-api.bespoken.tools",
-    method = "POST",
-    headers = { "Content-Type": "application/json" }) => {
-    // eslint-disable-next-line
-    const { hostname: host, port, protocol, pathname: path } = new URL(osPath.join(baseUrl, "/source/testRunHistory"));
+const postDataIntoEndpoint = async (payload) => {
+    const baseUrl = process.env.BESPOKEN_API_BASE_URL || "https://bespoken-api.bespoken.tools";
+    const method = "POST";
+    const headers = { "Content-Type": "application/json" };
+
+    const endpointUrl = new URL(baseUrl);// eslint-disable-line
+    endpointUrl.pathname = "/reporting/testResults";// eslint-disable-line
+
+    const { hostname: host, port, protocol, pathname: path } = endpointUrl;// eslint-disable-line
     return HTTP.post({ headers, host, method, path, port, protocol }, payload);
 };
 

--- a/lib/runner/ResultsPublisher.js
+++ b/lib/runner/ResultsPublisher.js
@@ -1,0 +1,169 @@
+const _ = require("lodash");
+const HTTP = require("../util/HTTP");
+const LoggingErrorHelper = require("../util/LoggingErrorHelper");
+const osPath = require("path");
+
+const buildTestResult = (testResult) => {
+    const start_timestamp = _.get(testResult, "_stopWatch.start", null);
+    const end_timestamp = _.get(testResult, "_stopWatch.end", null);
+    const test_name = _.get(testResult, "_test._description", "<no _test._description provided>").toString();
+
+    const tags = _.castArray(_.get(testResult, "_test._tags", [])).map(s => s.toString());
+    const raw_response_json = _.get(testResult, "_interactionResults", [{ error: "<no [${i}].interactionResults>" }]).map(e => e._rawResponse);
+    const raw_config_json = _.omit(_.get(testResult, "_test._testSuite._configuration", { error: "<no _testSuite._configuration>" }), ["_yaml"]);
+
+    const raw_json = JSON.stringify(testResult);
+    const skipped = _.get(testResult, "_test._skip", false);
+
+    const project_id = _.get(testResult, "_test._testSuite._projectId");
+    const bespoken_project_id = _.get(testResult, "_test._testSuite._bespokenProjectId");
+    const customer_id = _.get(testResult, "_test._testSuite._customerId");
+    const test_run_id = _.get(testResult, "_test._testSuite._runId");
+
+    const origin = _.get(testResult, "_test._testSuite._origin");
+    const platform = _.get(testResult, "_test._testSuite._platform");
+
+    const locale = _.get(testResult, "_test._testSuite._configuration.locale");
+    const voice_id = _.get(testResult, "_test._testSuite._configuration.voiceId");
+    const test_suite_name = _.get(testResult, "_test._testSuite._description", "").toString();
+    const test_suite_filename = osPath.relative(process.cwd(), _.get(testResult, "_test._testSuite._fileName", ""));
+
+
+    return {
+        bespoken_project_id,
+        customer_id,
+        end_timestamp,
+        locale,
+        origin,
+        platform,
+        project_id,
+        raw_config_json,
+        raw_json,
+        raw_response_json,
+        skipped,
+        start_timestamp,
+        tags,
+        test_name,
+        test_run_id,
+        test_suite_filename,
+        test_suite_name,
+        voice_id,
+    };
+};
+
+const buildTestInteractionResult = testInteractionResult => (testInteraction, index) => {
+    const _interactionResult = _.get(testInteractionResult, `[${index}]`, {});
+    const interactionDto = _.get(_interactionResult, "interactionDto", {});
+
+    const message = _.get(testInteraction, "_utterance", "<no utterance>");
+    const transcript = _.get(_interactionResult, "_rawResponse.transcript", "<no rawResponse.transcript>");
+    const display = _.get(_interactionResult, "_rawResponse.display", "<no display provided>");
+    const assertion = _.get(interactionDto, "assertions", "<no utterance>");
+    const result = _.get(interactionDto, "result.passed", null) ? "PASSED" : "FAILED";
+    const raw_response = _.get(_interactionResult, "_rawResponse", null);
+
+    return {
+        assertion,
+        display,
+        message,
+        raw_response,
+        result,
+        transcript,
+    };
+};
+
+const transformIntoPayload = (data) => {
+    const test_results = _.get(data, "results.testResults", [])
+        // gather all bespoken results of every test suite execution
+        .map(e => e.bespokenResults)
+        // join all executed test from different test suites
+        .reduce((p, c) => p.concat(c), [])
+        // prepare test data
+        .map((e) => {
+            const testResultProperties = buildTestResult(e);
+            const test_interaction_results = _.get(e, "_test._interactions", [])
+                .map(buildTestInteractionResult(_.get(e, "_interactionResults", [])));
+            const result = !test_interaction_results
+                .filter(e => !e.skipped)
+                .reduce((previous, current, index, all) => all, [{}])
+                .some(e => e.result !== true) ? "PASSED" : "FAILED";
+
+            return _.assign({
+                result,
+                test_interaction_results,
+            }, testResultProperties);
+        });
+
+    const {
+        bespoken_project_id,
+        customer_id,
+        origin,
+        platform,
+        project_id,
+        test_run_id,
+    } = _.get(test_results, "[0]", {});
+
+    const { 0: start_timestamp, 1: end_timestamp } = test_results
+        .map(e => [e.start_timestamp, e.end_timestamp])
+        .reduce((p, c) => p.concat(c), [])
+        .map(e => new Date(e))
+        .sort()
+        .filter((_, i, a) => i === 0 || i === a.length - 1);
+
+
+    const raw_json = null;
+
+    const test_suites_passed = _.get(data, "results.numPassedTestSuites", 0);
+    const test_suites_failed = _.get(data, "results.numFailedTestSuites", 0);
+    const test_suites_skipped = _.get(data, "results.numPendingTestSuites", 0);
+    const tests_passed = _.get(data, "results.numPassedTests", 0);
+    const tests_failed = _.get(data, "results.numFailedTests", 0);
+    const tests_skipped = _.get(data, "results.numPendingTests", 0);
+    const result = _.get(data, "results.success", false) ? "PASSED" : "FAILED";
+
+    return {
+        bespoken_project_id,
+        customer_id,
+        end_timestamp,
+        origin,
+        platform,
+        project_id,
+        raw_json,
+        result,
+        start_timestamp,
+        test_results,
+        test_run_id,
+        test_suites_failed,
+        test_suites_passed,
+        test_suites_skipped,
+        tests_failed,
+        tests_passed,
+        tests_skipped,
+    };
+};
+
+const postDataIntoEndpoint = async (payload,
+    baseUrl = process.env.SOURCE_API_BASE_URL || "https://bespoken-api.bespoken.tools",
+    method = "POST",
+    headers = { "Content-Type": "application/json" }) => {
+    // eslint-disable-next-line
+    const { hostname: host, port, protocol, pathname: path } = new URL(osPath.join(baseUrl, "/source/testRunHistory"));
+    return HTTP.post({ headers, host, method, path, port, protocol }, payload);
+};
+
+class ResultsPublisher {
+    async publishResults(data) {
+        return Promise.resolve()
+            .then(() => transformIntoPayload(data))
+            .then(payload => postDataIntoEndpoint(payload))
+            .catch(err => LoggingErrorHelper.error("bst-test", `Error saving test results Raw Error: ${JSON.stringify(err)}`));
+    }
+}
+
+module.exports = {
+    ResultsPublisher,
+    buildTestInteractionResult,
+    buildTestResult,
+    postDataIntoEndpoint,
+    transformIntoPayload,
+};

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -7,7 +7,9 @@ const fs = require("fs");
 const HTTP = require("../util/HTTP");
 const InteractionResult = require("../test/TestResult").InteractionResult;
 const LoggingErrorHelper = require("../util/LoggingErrorHelper");
+const osPath = require("path");
 const SmapiError = require("../util/SmapiError");
+const StopWatch = require("../util/StopWatch");
 const TestParser = require("../test/TestParser");
 const TestResult = require("../test/TestResult").TestResult;
 const url = require("url");
@@ -117,6 +119,10 @@ module.exports = class TestRunner {
 
         const getSourceExistPromise = this.getSourceExists(testSuiteWithLocale);
         const startTimeTestSuite = new Date();
+
+        const stopWatchTestSuite = new StopWatch();
+
+        stopWatchTestSuite.resetAndStart();
         for (const test of testSuiteWithLocale.tests) {
 
             await Util.executeFilter(testSuite.filterArray(), "onTestStart", test);
@@ -138,7 +144,13 @@ module.exports = class TestRunner {
                 console.log(chalk.yellow("Warning: \"Goto\" and \"Exit\" functionality are only available when running in sequential mode, set \"batchEnabled\" property to false to enable it"));
             }
 
+            const stopWatchTest = new StopWatch();
+            stopWatchTest.resetAndStart();
             const results = await this.executeRunWrapper(batchEnabled, asyncMode, invoker, testSuiteWithLocale, test.interactions, context);
+            stopWatchTest.stop();
+
+            _.set(testResult, "_stopWatch", stopWatchTest.toDto());
+
             testResult.interactionResults = results;
 
             if (invoker.currentConversation) {
@@ -151,6 +163,21 @@ module.exports = class TestRunner {
             this.emit("onTestEnd");
 
         }
+        stopWatchTestSuite.stop();
+
+        const customerId = await this.getCustomerIdFromSource(testSuiteWithLocale.virtualDeviceToken);
+
+        testResults.forEach((e) => {
+            _.set(e, "_test._testSuite._stopWatch", stopWatchTestSuite.toDto());
+            _.set(e, "_test._testSuite._customerId", customerId);
+            _.set(e, "_test._testSuite._runId", testSuiteWithLocale.runId);
+            _.set(e, "_test._testSuite._projectId", testSuiteWithLocale.projectId);
+            _.set(e, "_test._testSuite._bespokenProjectId", testSuiteWithLocale.bespokenProjectId);
+            _.set(e, "_test._testSuite._virtualDeviceToken", testSuiteWithLocale.virtualDeviceToken);
+
+            _.set(e, "_test._testSuite._platform", testSuiteWithLocale.platform);
+            _.set(e, "_test._testSuite._origin", testSuiteWithLocale.type);
+        });
 
         await this.saveTestResults(testResults, testSuiteWithLocale, startTimeTestSuite, getSourceExistPromise);
         await invoker.after(testSuiteWithLocale);
@@ -636,4 +663,16 @@ module.exports = class TestRunner {
         }
     }
 
+    async getCustomerIdFromSource(virtualDeviceToken,
+        baseUrl = process.env.SOURCE_API_BASE_URL || "https://source-api.bespoken.tools",
+        method = "GET",
+        headers = { "Content-Type": "application/json" }) {
+        const {
+            // eslint-disable-next-line
+            hostname: host, port, protocol, pathname, search
+        } = new URL(osPath.join(baseUrl, `/v1/quotaUsage?userToken=${virtualDeviceToken}&startDate=${new Date().toJSON()}`));
+        // eslint-disable-next-line
+        const path = `${pathname}${search}`;
+        return HTTP.get({ headers, host, method, path, port, protocol }).then(e => _.get(e, "json.userId", "<error no userId>")).catch(() => "<error dummy customer id>");
+    }
 };

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -117,9 +117,6 @@ module.exports = class TestRunner {
             console.log(chalk.yellow(retryNumberWarning));
         }
 
-        const getSourceExistPromise = this.getSourceExists(testSuiteWithLocale);
-        const startTimeTestSuite = new Date();
-
         const stopWatchTestSuite = new StopWatch();
 
         stopWatchTestSuite.resetAndStart();
@@ -179,12 +176,10 @@ module.exports = class TestRunner {
             _.set(e, "_test._testSuite._origin", testSuiteWithLocale.type);
         });
 
-        await this.saveTestResults(testResults, testSuiteWithLocale, startTimeTestSuite, getSourceExistPromise);
         await invoker.after(testSuiteWithLocale);
-
         await Util.executeFilter(testSuite.filterArray(), "onTestSuiteEnd", testResults);
-        this.emit("onTestSuiteEnd");
 
+        this.emit("onTestSuiteEnd");
 
         return testResults;
     }
@@ -567,99 +562,6 @@ module.exports = class TestRunner {
                     .join(" ");
                 interaction.localizedUtterance = localizedValue;
             }
-        }
-    }
-
-    async getSourceExists(testSuite) {
-        const id = testSuite.bespokenProjectId;
-        if (!id) {
-            return false;
-        }
-
-        const urlString = process.env.SOURCE_API_BASE_URL || "https://source-api.bespoken.tools";
-        const urlParts = url.parse(urlString);
-        const options = {
-            headers: {
-                "Content-Type": "application/json",
-            },
-            host: urlParts.hostname,
-            method: "GET",
-            path: "/v1/getSourceExists?id=" + id,
-            port: urlParts.port,
-            protocol: urlParts.protocol,
-        };
-
-        try {
-            const response = await HTTP.get(options);
-            if (response.message.statusCode !== 200) {
-                LoggingErrorHelper.error("bst-test", "Error getSourceExists" + " Raw Error: " + response.body.trim());
-                return false;
-            }
-            return response.body == "true";
-        } catch (error) {
-            LoggingErrorHelper.error("Error saving test results: ", error);
-            return false;
-        }
-    }
-
-    async saveTestResults(testResults, testSuite, startTimeTestSuite, getSourceExistsPromise) {
-        const { bespokenProjectId, fileName, virtualDeviceToken, runId, type } = testSuite;
-        if (type !== "e2e") {
-            return;
-        }
-
-        if (!bespokenProjectId) {
-            return;
-        }
-
-        const sourceExists = await getSourceExistsPromise;
-        if (!sourceExists) {
-            // eslint-disable-next-line no-console
-            console.log(chalk.yellow("The given bespokenProjectId does not exist. The test history won't be saved"));
-            return;
-        }
-
-        const urlString = process.env.SOURCE_API_BASE_URL || "https://source-api.bespoken.tools";
-        const urlParts = url.parse(urlString);
-
-        const options = {
-            headers: {
-                "Content-Type": "application/json",
-            },
-            host: urlParts.hostname,
-            method: "POST",
-            path: "/v2/testResultsHistory",
-            port: urlParts.port,
-            protocol: urlParts.protocol,
-        };
-
-        testResults = testResults.map((testResult) => {
-            const result = testResult.toDTO();
-            if (testResult.interactionResults && testResult.interactionResults.length) {
-                for (let i = 0; i < testResult.interactionResults.length; i++) {
-                    if (result && result.test && result.test.interactions
-                        && result.test.interactions.length > i) {
-                        result.test.interactions[i] = testResult.interactionResults[i].interactionDto;
-                    }
-                }
-            }
-            return result;
-        });
-        const body = {
-            projectId: bespokenProjectId,
-            runId,
-            testResults,
-            testSuite: fileName,
-            timestamp: startTimeTestSuite,
-            token: virtualDeviceToken,
-        };
-        try {
-            const response = await HTTP.post(options, body);
-            if (response.message.statusCode !== 200) {
-                LoggingErrorHelper.error("bst-test", "Error saving test results" + " Raw Error: " + response.body.trim());
-            }
-        } catch (error) {
-            LoggingErrorHelper.error("Error saving test results: ", error);
         }
     }
 

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -12,7 +12,6 @@ const SmapiError = require("../util/SmapiError");
 const StopWatch = require("../util/StopWatch");
 const TestParser = require("../test/TestParser");
 const TestResult = require("../test/TestResult").TestResult;
-const url = require("url");
 const Util = require("../util/Util");
 
 module.exports = class TestRunner {

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -7,7 +7,6 @@ const fs = require("fs");
 const HTTP = require("../util/HTTP");
 const InteractionResult = require("../test/TestResult").InteractionResult;
 const LoggingErrorHelper = require("../util/LoggingErrorHelper");
-const osPath = require("path");
 const SmapiError = require("../util/SmapiError");
 const StopWatch = require("../util/StopWatch");
 const TestParser = require("../test/TestParser");
@@ -161,7 +160,8 @@ module.exports = class TestRunner {
         }
         stopWatchTestSuite.stop();
 
-        const customerId = await this.getCustomerIdFromSource(testSuiteWithLocale.virtualDeviceToken).catch(() => "<error getting customer id>");
+        const customerId = await this.getCustomerIdFromSource(testSuiteWithLocale.virtualDeviceToken)
+            .catch(() => "<error getting customer id>");
 
         testResults.forEach((e) => {
             _.set(e, "_test._testSuite._stopWatch", stopWatchTestSuite.toDto());
@@ -563,18 +563,27 @@ module.exports = class TestRunner {
             }
         }
     }
-    async getCustomerIdFromSource(virtualDeviceToken,
-        baseUrl = process.env.SOURCE_API_BASE_URL || "https://source-api.bespoken.tools",
-        method = "GET",
-        headers = { "Content-Type": "application/json" }) {
+    async getCustomerIdFromSource(virtualDeviceToken) {
+        const baseUrl = process.env.SOURCE_API_BASE_URL || "https://source-api.bespoken.tools";
+        const method = "GET";
+        const headers = { "Content-Type": "application/json" };
+        const requestURL = new URL(baseUrl);
+
+        requestURL.pathname = "/v1/quotaUsage";// eslint-disable-line
+        requestURL.search = "";
+        requestURL.searchParams.append("userToken", virtualDeviceToken);// eslint-disable-line
+        requestURL.searchParams.append("startDate", new Date().toJSON());// eslint-disable-line
+
         const {
-            // eslint-disable-next-line
-            hostname: host, port, protocol, pathname, search
-        } = new URL(osPath.join(baseUrl, `/v1/quotaUsage?userToken=${virtualDeviceToken}&startDate=${new Date().toJSON()}`));
-        // eslint-disable-next-line
-        const path = `${pathname}${search}`;
-        return HTTP.get({ headers, host, method, path, port, protocol })
-            .then(e => _.get(e, "json.userId", "<error no userId>"))
-            .catch(() => "<error getting customer id>");
+            hostname: host,
+            port,
+            protocol,
+            pathname, // eslint-disable-line
+            search,
+        } = requestURL;
+
+        const path = `${pathname}${search}`;// eslint-disable-line
+        return HTTP.get(({ headers, host, method, path, port, protocol }))
+            .then(e => _.get(e, "json.userId"));
     }
 };

--- a/lib/runner/TestRunner.js
+++ b/lib/runner/TestRunner.js
@@ -161,7 +161,7 @@ module.exports = class TestRunner {
         }
         stopWatchTestSuite.stop();
 
-        const customerId = await this.getCustomerIdFromSource(testSuiteWithLocale.virtualDeviceToken);
+        const customerId = await this.getCustomerIdFromSource(testSuiteWithLocale.virtualDeviceToken).catch(() => "<error getting customer id>");
 
         testResults.forEach((e) => {
             _.set(e, "_test._testSuite._stopWatch", stopWatchTestSuite.toDto());
@@ -563,7 +563,6 @@ module.exports = class TestRunner {
             }
         }
     }
-
     async getCustomerIdFromSource(virtualDeviceToken,
         baseUrl = process.env.SOURCE_API_BASE_URL || "https://source-api.bespoken.tools",
         method = "GET",
@@ -574,6 +573,8 @@ module.exports = class TestRunner {
         } = new URL(osPath.join(baseUrl, `/v1/quotaUsage?userToken=${virtualDeviceToken}&startDate=${new Date().toJSON()}`));
         // eslint-disable-next-line
         const path = `${pathname}${search}`;
-        return HTTP.get({ headers, host, method, path, port, protocol }).then(e => _.get(e, "json.userId", "<error no userId>")).catch(() => "<error dummy customer id>");
+        return HTTP.get({ headers, host, method, path, port, protocol })
+            .then(e => _.get(e, "json.userId", "<error no userId>"))
+            .catch(() => "<error getting customer id>");
     }
 };

--- a/lib/util/StopWatch.js
+++ b/lib/util/StopWatch.js
@@ -1,0 +1,45 @@
+/**
+ * Class to store and calculate elapsed time between two execution.
+ */
+module.exports = class StopWatch {
+
+    constructor() {
+        this._end = null;
+        this._start = null;
+    }
+    /**
+     * Reset the start timestamp to now.
+     */
+    resetAndStart() {
+        this._start = new Date();
+        this._end = null;
+    }
+
+    /**
+     * Update the value of end timestamp
+     */
+    stop() {
+        this._end = new Date();
+    }
+
+    get elapsedTime() {
+        try {
+            return this._end.getTime() - this._start.getTime();
+        } catch (ex) {
+            return -1;
+        }
+    }
+
+    /**
+     * Converts information into a Dto  
+     * @returns object with the information of the start timestamp, end timestamp and elapsed time in milliseconds
+     */
+    toDto() {
+        const start = new Date(this._start);
+        const end = new Date(this._end);
+        const elapsedTime = this.elapsedTime;
+
+        return { elapsedTime, end, start };
+    }
+
+};

--- a/lib/util/Util.js
+++ b/lib/util/Util.js
@@ -17,7 +17,7 @@ module.exports = class Util {
 
         if (s.startsWith("\"")
             && s.endsWith("\"")) {
-            s = s.substr(1, s.length-2).toString();
+            s = s.substr(1, s.length - 2).toString();
         }
         return s.toString();
     }
@@ -90,11 +90,11 @@ module.exports = class Util {
     static async sleep(time) {
         return new Promise((resolve) => {
             setTimeout(() => {
-                resolve();        
+                resolve();
             }, time);
         });
     }
-    
+
     static padZero(original, characters) {
         const sliceValue = -1 * (characters ? characters : 2);
         return ("0" + original).slice(sliceValue);
@@ -105,7 +105,7 @@ module.exports = class Util {
         const notEmpty = value => value && value.trim() !== "";
         const toSlot = (accumulator, item) => {
             const [key, val] = item.split("=");
-            accumulator[key] = val.replace(/"/g, "") ;
+            accumulator[key] = val.replace(/"/g, "");
             return accumulator;
         };
         const intentRegex = /([\w|.|-]*)((?: \w*=(?:"(?:[^"])*"|(?:[^ ])*))*)/;
@@ -122,15 +122,15 @@ module.exports = class Util {
     }
 
     static formatDate(date) {
-        return date.getFullYear() + "-" + Util.padZero(date.getMonth()+1)+ "-" + Util.padZero(date.getDate()) + "T" +
-             Util.padZero(date.getHours()) + ":" + Util.padZero(date.getMinutes()) + ":" +
-             Util.padZero(date.getSeconds()) + "." + Util.padZero(date.getMilliseconds(), 3);
+        return date.getFullYear() + "-" + Util.padZero(date.getMonth() + 1) + "-" + Util.padZero(date.getDate()) + "T" +
+            Util.padZero(date.getHours()) + ":" + Util.padZero(date.getMinutes()) + ":" +
+            Util.padZero(date.getSeconds()) + "." + Util.padZero(date.getMilliseconds(), 3);
     }
 
     static async readFiles(dirname) {
         return new Promise((resolve, reject) => {
             try {
-                if(!fs.existsSync(dirname)) {
+                if (!fs.existsSync(dirname)) {
                     resolve([]);
                 }
                 const files = fs.readdirSync(dirname);
@@ -164,10 +164,10 @@ module.exports = class Util {
         // We get the key values for creating the ASK config from environment variables
         if (
             !process.env.ASK_ACCESS_TOKEN ||
-			!process.env.ASK_REFRESH_TOKEN ||
-			!process.env.ASK_VENDOR_ID ||
-			!process.env.ASK_SKILL_ID ||
-			!process.env.VIRTUAL_DEVICE_TOKEN
+            !process.env.ASK_REFRESH_TOKEN ||
+            !process.env.ASK_VENDOR_ID ||
+            !process.env.ASK_SKILL_ID ||
+            !process.env.VIRTUAL_DEVICE_TOKEN
         ) {
             throw new Error(
                 "Environment variables ASK_ACCESS_TOKEN, ASK_REFRESH_TOKEN, ASK_VENDOR_ID, ASK_SKILL_ID and VIRTUAL_DEVICE_TOKEN must all be set"
@@ -201,21 +201,21 @@ module.exports = class Util {
         if (!fs.existsSync(askDir)) {
             fs.mkdirSync(askDir);
         }
-        fs.writeFileSync(askConfigPath, JSON.stringify(askConfigJSON));        
+        fs.writeFileSync(askConfigPath, JSON.stringify(askConfigJSON));
     }
 
-    static isErrorObject(e){
+    static isErrorObject(e) {
         return e && e.stack && e.message && typeof e.stack === "string"
             && typeof e.message === "string";
     }
-    
+
     static filterExist(filters, filterName) {
         if (filters && filters.length) {
             for (let index = 0; index < filters.length; index++) {
                 const filter = filters[index];
                 if (filter && filter[filterName]) {
                     return true;
-                }  
+                }
             }
         }
         return false;
@@ -231,7 +231,7 @@ module.exports = class Util {
                     if (!result && typeof filterResult !== "undefined") {
                         result = filterResult;
                     }
-                }  
+                }
             }
         }
         return result;
@@ -247,10 +247,27 @@ module.exports = class Util {
                     if (!result && typeof filterResult !== "undefined") {
                         result = filterResult;
                     }
-                }  
+                }
             }
         }
 
         return result;
+    }
+
+    static noCircularReplaceHelper(cache = []) {
+        return (key, value) => {
+            if (typeof value === "object" && value !== null) {
+                // Duplicate reference found, discard key
+                if (cache.includes(value)) return;
+
+                // Store value in our collection
+                cache.push(value);
+            }
+            return value;
+        };
+    }
+
+    static cloneWithoutCircularReference(obj) {
+        return JSON.parse(JSON.stringify(obj, Util.noCircularReplaceHelper()));
     }
 };

--- a/test/JestAdapter.test.js
+++ b/test/JestAdapter.test.js
@@ -8,7 +8,7 @@ const TestSuite = require("../lib/test/TestSuite");
 
 describe("JestAdapter", () => {
     test("Runs a mock test that succeeds with description", async () => {
-        const testSuite = new TestSuite("MyTest.yml", { description: "TestSuite Description"});
+        const testSuite = new TestSuite("MyTest.yml", { description: "TestSuite Description" });
         const test = new Test(testSuite, { description: "Test Description" });
         const testResult = new TestResult(test);
         testResult.locale = "en-US";
@@ -30,7 +30,6 @@ describe("JestAdapter", () => {
         expect(jestResults.numFailingTests).toBe(0);
         expect(jestResults.testResults.length).toBe(2);
         expect(jestResults.testFilePath).toBe("MyTest.yml");
-
         // Check the individual test result
         const jestTestResult = jestResults.testResults[0];
         expect(jestTestResult.ancestorTitles[0]).toBe("TestSuite Description (en-US)");
@@ -261,7 +260,7 @@ class Runtime {
         FakeVirtualAlexaRunner.results = results;
     }
 
-    requireModule () {
+    requireModule() {
         return FakeVirtualAlexaRunner;
     }
 }

--- a/test/ResultsPublisher.test.js
+++ b/test/ResultsPublisher.test.js
@@ -1,0 +1,180 @@
+const _ = require("lodash");
+const { transformIntoPayload } = require("../lib/runner/ResultsPublisher");
+
+describe("ResultsPublisher", () => {
+    test("Should create empty payload When passed empty object", async () => {
+
+        const payload = transformIntoPayload({});
+
+        expect(payload).toBeDefined();
+
+        expect(payload).toHaveProperty("test_run_id");
+        expect(payload).toHaveProperty("customer_id");
+        expect(payload).toHaveProperty("project_id");
+        expect(payload).toHaveProperty("origin");
+        expect(payload).toHaveProperty("platform");
+        expect(payload).toHaveProperty("start_timestamp");
+        expect(payload).toHaveProperty("end_timestamp");
+        expect(payload).toHaveProperty("raw_json");
+        expect(payload).toHaveProperty("test_suites_passed");
+        expect(payload).toHaveProperty("test_suites_failed");
+        expect(payload).toHaveProperty("tests_passed");
+        expect(payload).toHaveProperty("tests_failed");
+        expect(payload).toHaveProperty("tests_skipped");
+        expect(payload).toHaveProperty("result", "FAILED");
+
+        //expect(stopWatch.toDto()).toHaveProperty("start");
+        //expect(stopWatch.toDto()).toHaveProperty("end");
+    });
+
+    test("Should create empty payload When passed null object", async () => {
+
+        const payload = transformIntoPayload(null);
+
+        expect(payload).toBeDefined();
+
+        expect(payload).toHaveProperty("test_run_id");
+        expect(payload).toHaveProperty("customer_id");
+        expect(payload).toHaveProperty("project_id");
+        expect(payload).toHaveProperty("origin");
+        expect(payload).toHaveProperty("platform");
+        expect(payload).toHaveProperty("start_timestamp");
+        expect(payload).toHaveProperty("end_timestamp");
+        expect(payload).toHaveProperty("raw_json");
+        expect(payload).toHaveProperty("test_suites_passed");
+        expect(payload).toHaveProperty("test_suites_failed");
+        expect(payload).toHaveProperty("tests_passed");
+        expect(payload).toHaveProperty("tests_failed");
+        expect(payload).toHaveProperty("tests_skipped");
+        expect(payload).toHaveProperty("result", "FAILED");
+    });
+
+    test("Should create empty payload When one single test result passed test run", async () => {
+        const jestResults = {};
+
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._test._testSuite._runId", "__run_id__");
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._test._testSuite._projectId", "__project_id__");
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._test._testSuite._customerId", "__customer_id__");
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._test._testSuite._bespokenProjectId", "__bespoken_project_id__");
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._test._testSuite._virtualDeviceToken", "__virtual_token__");
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._test._testSuite._platform", "__platform__");
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._test._testSuite._origin", "__origin__");
+
+
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._test._interactions[0]._utterance", "__message__");
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._interactionResults[0].", {});
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._interactionResults[0]._rawResponse.transcript", "__transcript__");
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._interactionResults[0]._rawResponse.display", "__display__");
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._interactionResults[0]._rawResponse", {});
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._interactionResults[0].interactionDto.assertions", {});
+        _.set(jestResults, "results.testResults[0].bespokenResults[0]._interactionResults[0].interactionDto.result.passed", true);
+
+
+        const payload = transformIntoPayload(jestResults);
+
+        expect(payload).toBeDefined();
+
+        expect(Object.keys(payload).sort())
+            .toStrictEqual([
+                "bespoken_project_id",
+                "customer_id",
+                "end_timestamp",
+                "origin",
+                "platform",
+                "project_id",
+                "raw_json",
+                "result",
+                "start_timestamp",
+                "test_results",
+                "test_run_id",
+                "test_suites_failed",
+                "test_suites_passed",
+                "test_suites_skipped",
+                "tests_failed",
+                "tests_passed",
+                "tests_skipped",
+            ]);
+
+        expect(payload).toHaveProperty("test_run_id", "__run_id__");
+        expect(payload).toHaveProperty("customer_id", "__customer_id__");
+        expect(payload).toHaveProperty("project_id", "__project_id__");
+        expect(payload).toHaveProperty("bespoken_project_id", "__bespoken_project_id__");
+        expect(payload).toHaveProperty("origin", "__origin__");
+        expect(payload).toHaveProperty("platform", "__platform__");
+        expect(payload).toHaveProperty("start_timestamp");
+        expect(payload).toHaveProperty("end_timestamp");
+        expect(payload).toHaveProperty("raw_json");
+        expect(payload).toHaveProperty("test_suites_passed");
+        expect(payload).toHaveProperty("test_suites_failed");
+        expect(payload).toHaveProperty("tests_passed");
+        expect(payload).toHaveProperty("tests_failed");
+        expect(payload).toHaveProperty("tests_skipped");
+        expect(payload).toHaveProperty("result", "FAILED");
+        expect(payload).toHaveProperty("test_results");
+        expect(payload.test_results).toHaveLength(1);
+
+
+        expect(Object.keys(payload.test_results[0]).sort())
+            .toStrictEqual([
+                "bespoken_project_id",
+                "customer_id",
+                "end_timestamp",
+                "locale",
+                "origin",
+                "platform",
+                "project_id",
+                "raw_config_json",
+                "raw_json",
+                "raw_response_json",
+                "result",
+                "skipped",
+                "start_timestamp",
+                "tags",
+                "test_interaction_results",
+                "test_name",
+                "test_run_id",
+                "test_suite_filename",
+                "test_suite_name",
+                "voice_id",
+            ]);
+
+        expect(payload.test_results[0]).toHaveProperty("bespoken_project_id");
+        expect(payload.test_results[0]).toHaveProperty("customer_id");
+        expect(payload.test_results[0]).toHaveProperty("end_timestamp");
+        expect(payload.test_results[0]).toHaveProperty("locale");
+        expect(payload.test_results[0]).toHaveProperty("origin");
+        expect(payload.test_results[0]).toHaveProperty("platform");
+        expect(payload.test_results[0]).toHaveProperty("project_id");
+        expect(payload.test_results[0]).toHaveProperty("raw_config_json");
+        expect(payload.test_results[0]).toHaveProperty("raw_json");
+        expect(payload.test_results[0]).toHaveProperty("raw_response_json");
+        expect(payload.test_results[0]).toHaveProperty("skipped");
+        expect(payload.test_results[0]).toHaveProperty("start_timestamp");
+        expect(payload.test_results[0]).toHaveProperty("tags");
+        expect(payload.test_results[0]).toHaveProperty("test_name");
+        expect(payload.test_results[0]).toHaveProperty("test_run_id");
+        expect(payload.test_results[0]).toHaveProperty("test_suite_filename");
+        expect(payload.test_results[0]).toHaveProperty("test_suite_name");
+        expect(payload.test_results[0]).toHaveProperty("voice_id");
+        expect(payload.test_results[0]).toHaveProperty("test_interaction_results");
+        expect(payload.test_results[0].test_interaction_results).toHaveLength(1);
+
+        expect(Object.keys(payload.test_results[0].test_interaction_results[0]).sort())
+            .toStrictEqual([
+                "assertion",
+                "display",
+                "message",
+                "raw_response",
+                "result",
+                "transcript",
+            ]);
+
+        expect(payload.test_results[0].test_interaction_results[0]).toHaveProperty("assertion");
+        expect(payload.test_results[0].test_interaction_results[0]).toHaveProperty("display");
+        expect(payload.test_results[0].test_interaction_results[0]).toHaveProperty("message");
+        expect(payload.test_results[0].test_interaction_results[0]).toHaveProperty("raw_response");
+        expect(payload.test_results[0].test_interaction_results[0]).toHaveProperty("result");
+        expect(payload.test_results[0].test_interaction_results[0]).toHaveProperty("transcript");
+    });
+
+});

--- a/test/StopWatch.test.js
+++ b/test/StopWatch.test.js
@@ -1,0 +1,14 @@
+const StopWatch = require("../lib/util/StopWatch");
+
+describe("StopWatch", () => {
+    test("get elapsed time", async () => {
+        const stopWatch = new StopWatch();
+        stopWatch.resetAndStart();
+
+        await new Promise(resolve => setTimeout(resolve, 5000)).then(() => stopWatch.stop());
+
+        expect(stopWatch.toDto()).toHaveProperty("elapsedTime", 5000);
+        expect(stopWatch.toDto()).toHaveProperty("start");
+        expect(stopWatch.toDto()).toHaveProperty("end");
+    });
+});

--- a/test/StopWatch.test.js
+++ b/test/StopWatch.test.js
@@ -5,9 +5,10 @@ describe("StopWatch", () => {
         const stopWatch = new StopWatch();
         stopWatch.resetAndStart();
 
-        await new Promise(resolve => setTimeout(resolve, 5000)).then(() => stopWatch.stop());
+        await new Promise(resolve => setTimeout(resolve, 1000)).then(() => stopWatch.stop());
 
-        expect(stopWatch.toDto()).toHaveProperty("elapsedTime", 5000);
+        expect(stopWatch.toDto()).toHaveProperty("elapsedTime");
+        expect(stopWatch.toDto().elapsedTime).toBeGreaterThanOrEqual(1000);
         expect(stopWatch.toDto()).toHaveProperty("start");
         expect(stopWatch.toDto()).toHaveProperty("end");
     });

--- a/test/TestRunner.test.js
+++ b/test/TestRunner.test.js
@@ -39,9 +39,9 @@ describe("test runner", () => {
             const resultCallbackMock = jest.fn(resultCallback);
             runner.subscribe("message", messageCallbackMock);
             runner.subscribe("result", resultCallbackMock);
-      
+
             await runner.run("test/FactSkill/fact-skill-tests.yml");
-            
+
             expect(messageCallbackMock).toHaveBeenCalledTimes(6);
             expect(resultCallbackMock).toHaveBeenCalledTimes(6);
             expect(resultCallbackMock.mock.calls[1][1]).toBeDefined();
@@ -282,9 +282,9 @@ describe("test runner", () => {
         runner.subscribe("result", resultCallbackMock);
         runner.unsubscribe("message");
         runner.unsubscribe("result");
-  
+
         await runner.run("test/FactSkill/fact-skill-tests.yml");
-        
+
         expect(messageCallbackMock).toHaveBeenCalledTimes(0);
         expect(resultCallbackMock).toHaveBeenCalledTimes(0);
     });
@@ -303,7 +303,7 @@ describe("test runner", () => {
         const resultCallbackMock = jest.fn(resultCallback);
         runner.subscribe("message", messageCallbackMock);
         runner.subscribe("result", resultCallbackMock);
-        const loggerSpy = jest.spyOn(LoggingErrorHelper, "error").mockImplementation(() => {});
+        const loggerSpy = jest.spyOn(LoggingErrorHelper, "error").mockImplementation(() => { });
 
         try {
             await runner.run("test/FactSkill/fact-skill-tests.yml");
@@ -353,7 +353,7 @@ describe("test runner", () => {
         parser.load(yamlString);
         const testSuite = parser.parse();
         testSuite._fileName = " ";
-    
+
         const results = await runnerError.runSuite(testSuite);
         expect(results[0].interactionResults[0].errorOnProcess).toContain("Error from virtual device");
     });
@@ -363,7 +363,7 @@ describe("test runner", () => {
             type: CONSTANTS.TYPE.e2e,
             virtualDeviceToken: "123",
         });
-  
+
         await runner.run("test/FactSkill/fact-skill-tests.yml");
         expect(mockMessage.mock.calls.length).toBe(3);
         expect(process.env.JEST_STARE_COVERAGE_LINK).toBeUndefined();
@@ -402,12 +402,12 @@ describe("test runner", () => {
         });
 
         const mockReturn = [{}, {}, {}];
-        for (let i=0; i < 3; i++) {
+        for (let i = 0; i < 3; i++) {
             // Usual behavior, first result is empty and arrays with results appear then
             mockGetConversationResults
-                .mockReturnValueOnce({results: [], status: "IN-PROGRESS"})
-                .mockReturnValueOnce({results: mockReturn, status: "IN-PROGRESS"})
-                .mockReturnValueOnce({results: mockReturn, status: "COMPLETED"});
+                .mockReturnValueOnce({ results: [], status: "IN-PROGRESS" })
+                .mockReturnValueOnce({ results: mockReturn, status: "IN-PROGRESS" })
+                .mockReturnValueOnce({ results: mockReturn, status: "COMPLETED" });
         }
 
         await runner.run("test/FactSkill/fact-skill-tests.yml");
@@ -426,25 +426,25 @@ describe("test runner", () => {
         });
 
         const mockReturn = [{}, {}, {}];
-        for (let i=0; i < 3; i++) {
+        for (let i = 0; i < 3; i++) {
             // Usual behavior, first result is empty and arrays with results appear then
             mockGetConversationResults
-                .mockReturnValueOnce({results: [], status: "IN-PROGRESS"})
-                .mockReturnValueOnce({results: mockReturn, status: "IN-PROGRESS"})
-                .mockReturnValueOnce({results: mockReturn, status: "COMPLETED"});
+                .mockReturnValueOnce({ results: [], status: "IN-PROGRESS" })
+                .mockReturnValueOnce({ results: mockReturn, status: "IN-PROGRESS" })
+                .mockReturnValueOnce({ results: mockReturn, status: "COMPLETED" });
         }
 
         await runner.run("test/FactSkill/fact-skill-tests.goto.yml");
         // each of the three interactions have two utterances, plus the call that comes with an empty array
         expect(mockGetConversationResults.mock.calls.length).toBe(5);
-    });    
+    });
 
     test("getInvoker default value", async () => {
         Configuration.configure({});
 
         const testSuite = new TestSuite();
         const runner = new TestRunner();
-        
+
         expect(runner.getInvoker(testSuite)).toBe("VirtualAlexaInvoker");
     });
 
@@ -455,7 +455,7 @@ describe("test runner", () => {
 
         const testSuite = new TestSuite();
         const runner = new TestRunner();
-        
+
         expect(runner.getInvoker(testSuite)).toBe("VirtualDeviceInvoker");
     });
 
@@ -554,7 +554,7 @@ describe("test runner", () => {
                     expect(testResult).toBeDefined();
                     testEnd = true;
                 },
-                onTestStart:(test) => {
+                onTestStart: (test) => {
                     expect(test).toBeDefined();
                     testStart = true;
                 },
@@ -585,7 +585,7 @@ describe("test runner", () => {
                     expect(test.interactions[2].assertions[0].value).toBe("nothing at all");
                     testEnd = true;
                 },
-                onTestStart:(test) => {
+                onTestStart: (test) => {
                     expect(test).toBeDefined();
                     testStart = true;
                 },
@@ -625,7 +625,7 @@ describe("test runner", () => {
 
                     testEnd = true;
                 },
-                onTestStart:(test) => {
+                onTestStart: (test) => {
                     expect(test).toBeDefined();
                     testStart = true;
                 },
@@ -687,13 +687,13 @@ describe("test runner", () => {
 `;
 
         await Promise.all(["A", "B", "C"].map(async (token) => {
-            const configurationOverride = { locale: "en-US", type: CONSTANTS.TYPE.e2e, virtualDeviceToken: "token"+token};
+            const configurationOverride = { locale: "en-US", type: CONSTANTS.TYPE.e2e, virtualDeviceToken: "token" + token };
             const parser = new TestParser();
             parser.load(script);
-            
+
             const testSuite = parser.parse(configurationOverride);
             testSuite._fileName = "test";
-    
+
             const runner = new TestRunner();
             return await runner.runSuite(testSuite);
         }));
@@ -713,7 +713,7 @@ describe("test runner", () => {
 
     });
 
-    test("operator on test", async() => {
+    test("operator on test", async () => {
         const runner = new TestRunner({
             exclude: "broken",
             handler: "test/FactSkill/index.handler",
@@ -722,7 +722,7 @@ describe("test runner", () => {
         });
 
         const results = await runner.run("test/FactSkill/fact-skill-operators.yml");
-        
+
         expect(results.length).toEqual(1);
         expect(results[0].test.description).toEqual("Gets a new fact intent");
 
@@ -803,7 +803,7 @@ describe("test runner", () => {
         process.chdir("../..");
     });
 
-    test("stop execution when error on async mode", async() => {
+    test("stop execution when error on async mode", async () => {
         mockGetConversationResults.mockReset();
         const runner = new TestRunner({
             asyncE2EWaitInterval: 1,
@@ -831,7 +831,7 @@ describe("test runner", () => {
         expect(results[1].interactionResults[0].errorOnProcess).toContain("Async error");
     });
 
-    test("stop execution when status is completed on async mode", async() => {
+    test("stop execution when status is completed on async mode", async () => {
         mockGetConversationResults.mockReset();
         const runner = new TestRunner({
             asyncE2EWaitInterval: 1,
@@ -845,8 +845,8 @@ describe("test runner", () => {
 
         mockGetConversationResults.mockReturnValue({
             results: [
-                { message: "Hi", transcript: "hi result"},
-                { message: "Hi", transcript: "hi result"},
+                { message: "Hi", transcript: "hi result" },
+                { message: "Hi", transcript: "hi result" },
             ], status: "COMPLETED",
         });
 
@@ -861,258 +861,7 @@ describe("test runner", () => {
         expect(results[1].interactionResults.length).toBe(2);
 
         expect(results[2].skipped).toBe(false);
-        expect(results[2].interactionResults.length).toBe(2); 
-    });
-
-    describe("save test results", () => {
-        test("save test results successfully", async() => {
-            let parsedBody;
-    
-            nock("https://source-api.bespoken.tools")
-                .get("/v1/getSourceExists")
-                .query(() => {
-                    return true;
-                })
-                .reply(200, "true");
-    
-            nock("https://source-api.bespoken.tools")
-                .post("/v2/testResultsHistory", (body) => {
-                    parsedBody = body;
-                    return true;
-                }).reply(200, {
-                    id: "simulationId",
-                    status: "SUCCESSFUL",
-                });
-    
-            Configuration.configure({
-                batchEnabled: false,
-                bespokenProjectId: "testProject",
-                locale: "en-US",
-                type: CONSTANTS.TYPE.e2e,
-                virtualDeviceToken: "space fact",
-            });
-            const runnerError = new TestRunner();
-        
-            const yamlString = `---
-    - test: Simple test
-    - new fact: assertion
-    `;
-            const parser = new TestParser();
-            parser.load(yamlString);
-            const testSuite = parser.parse();
-            testSuite._fileName = " ";
-        
-            await runnerError.runSuite(testSuite);
-            expect(parsedBody.projectId).toBe("testProject");
-            expect(parsedBody.token).toBe("space fact");
-            expect(parsedBody.testResults.length).toBe(1);
-            expect(parsedBody.testResults[0].test.description).toBe("Simple test");
-            expect(parsedBody.testResults[0].test.interactions.length).toBe(1);
-            expect(parsedBody.testResults[0].test.interactions[0].assertions[0].actual).toBe("Here's your fact");
-            expect(parsedBody.testResults[0].test.interactions[0].assertions[0].value).toBe("assertion");
-            nock.cleanAll();
-        });
-    
-        test("not save test results if bespokenProjectId does not match a source id", async() => {
-            let parsedBody;
-    
-            nock("https://source-api.bespoken.tools")
-                .get("/v1/getSourceExists")
-                .query(() => {
-                    return true;
-                }).reply(200, "false");
-    
-            nock("https://source-api.bespoken.tools")
-                .post("/v2/testResultsHistory", (body) => {
-                    parsedBody = body;
-                    return true;
-                }).reply(200, {
-                    id: "simulationId",
-                    status: "SUCCESSFUL",
-                });
-    
-            Configuration.configure({
-                batchEnabled: false,
-                bespokenProjectId: "testProject",
-                locale: "en-US",
-                type: CONSTANTS.TYPE.e2e,
-                virtualDeviceToken: "space fact",
-            });
-            const runnerError = new TestRunner();
-        
-            const yamlString = `---
-    - test: Simple test
-    - new fact: assertion
-    `;
-            const parser = new TestParser();
-            parser.load(yamlString);
-            const testSuite = parser.parse();
-            testSuite._fileName = " ";
-        
-            await runnerError.runSuite(testSuite);
-            expect(parsedBody).toBeUndefined();
-            nock.cleanAll();
-        });
-
-        test("save test results when source api service throws exception on source exists", async() => {
-            let parsedBody;
-    
-            nock("https://source-api.bespoken.tools")
-                .get("/v1/getSourceExists")
-                .query(() => {
-                    return true;
-                })
-                .replyWithError("random error");
-    
-            nock("https://source-api.bespoken.tools")
-                .post("/v2/testResultsHistory", (body) => {
-                    parsedBody = body;
-                    return true;
-                }).reply(200, {
-                    id: "simulationId",
-                    status: "SUCCESSFUL",
-                });
-    
-            Configuration.configure({
-                batchEnabled: false,
-                bespokenProjectId: "testProject",
-                locale: "en-US",
-                type: CONSTANTS.TYPE.e2e,
-                virtualDeviceToken: "space fact",
-            });
-            const runnerError = new TestRunner();
-        
-            const yamlString = `---
-    - test: Simple test
-    - new fact: assertion
-    `;
-            const parser = new TestParser();
-            parser.load(yamlString);
-            const testSuite = parser.parse();
-            testSuite._fileName = " ";
-        
-            await runnerError.runSuite(testSuite);
-            expect(parsedBody).toBeUndefined();
-            nock.cleanAll();
-        });
-
-        test("save test results when source api service throws exception on saving ", async() => {
-            let parsedBody;
-    
-            nock("https://source-api.bespoken.tools")
-                .get("/v1/getSourceExists")
-                .query(() => {
-                    return true;
-                })
-                .reply(200, "true");
-    
-            nock("https://source-api.bespoken.tools")
-                .post("/v2/testResultsHistory", () => {
-                    return true;
-                }).replyWithError("random error");
-    
-            Configuration.configure({
-                batchEnabled: false,
-                bespokenProjectId: "testProject",
-                locale: "en-US",
-                type: CONSTANTS.TYPE.e2e,
-                virtualDeviceToken: "space fact",
-            });
-            const runnerError = new TestRunner();
-        
-            const yamlString = `---
-    - test: Simple test
-    - new fact: assertion
-    `;
-            const parser = new TestParser();
-            parser.load(yamlString);
-            const testSuite = parser.parse();
-            testSuite._fileName = " ";
-        
-            await runnerError.runSuite(testSuite);
-            expect(parsedBody).toBeUndefined();
-            nock.cleanAll();
-        });
-
-        test("save test results when source api service returns 500 error code", async() => {
-            let parsedBody;
-    
-            nock("https://source-api.bespoken.tools")
-                .get("/v1/getSourceExists")
-                .query(() => {
-                    return true;
-                })
-                .reply(500);
-    
-            nock("https://source-api.bespoken.tools")
-                .post("/v2/testResultsHistory", (body) => {
-                    parsedBody = body;
-                    return true;
-                }).reply(200, {
-                    id: "simulationId",
-                    status: "SUCCESSFUL",
-                });
-    
-            Configuration.configure({
-                batchEnabled: false,
-                bespokenProjectId: "testProject",
-                locale: "en-US",
-                type: CONSTANTS.TYPE.e2e,
-                virtualDeviceToken: "space fact",
-            });
-            const runnerError = new TestRunner();
-        
-            const yamlString = `---
-    - test: Simple test
-    - new fact: assertion
-    `;
-            const parser = new TestParser();
-            parser.load(yamlString);
-            const testSuite = parser.parse();
-            testSuite._fileName = " ";
-        
-            await runnerError.runSuite(testSuite);
-            expect(parsedBody).toBeUndefined();
-            nock.cleanAll();
-        });
-
-        test("save test results when source api service returns 500 error code", async() => {
-            let parsedBody;
-    
-            nock("https://source-api.bespoken.tools")
-                .get("/v1/getSourceExists")
-                .query(() => {
-                    return true;
-                })
-                .reply(200, "true");
-    
-            nock("https://source-api.bespoken.tools")
-                .post("/v2/testResultsHistory", () => {
-                    return true;
-                }).reply(500);
-    
-            Configuration.configure({
-                batchEnabled: false,
-                bespokenProjectId: "testProject",
-                locale: "en-US",
-                type: CONSTANTS.TYPE.e2e,
-                virtualDeviceToken: "space fact",
-            });
-            const runnerError = new TestRunner();
-        
-            const yamlString = `---
-    - test: Simple test
-    - new fact: assertion
-    `;
-            const parser = new TestParser();
-            parser.load(yamlString);
-            const testSuite = parser.parse();
-            testSuite._fileName = " ";
-        
-            await runnerError.runSuite(testSuite);
-            expect(parsedBody).toBeUndefined();
-            nock.cleanAll();
-        });
+        expect(results[2].interactionResults.length).toBe(2);
     });
 
 });

--- a/test/TestRunner.test.js
+++ b/test/TestRunner.test.js
@@ -4,8 +4,6 @@ const LoggingErrorHelper = require("../lib/util/LoggingErrorHelper");
 const mockGetConversationResults = require("virtual-device-sdk").mockGetConversationResults;
 const mockMessage = require("virtual-device-sdk").mockMessage;
 const mockVirtualDevice = require("virtual-device-sdk").mockVirtualDevice;
-const nock = require("nock");
-
 const TestParser = require("../lib/test/TestParser");
 const TestRunner = require("../lib/runner/TestRunner");
 const TestSuite = require("../lib/test/TestSuite");

--- a/test/Util.test.js
+++ b/test/Util.test.js
@@ -74,4 +74,21 @@ describe("succinct intent", () => {
         expect(intent).toBeUndefined();
 
     });
+
+    test("clone without circular reference", async () => {
+        const object = { parent: { child: { parent: null, value: 10 } } };
+        object.parent.child.parent = object.parent;
+
+        expect(Util.cloneWithoutCircularReference(object))
+            .toStrictEqual({ parent: { child: { value: 10 } } });
+    });
+
+
+    test("stringify circular reference", async () => {
+        const object = { parent: { child: { parent: null, value: 10 } } };
+        object.parent.child.parent = object.parent;
+
+        expect(JSON.stringify(object, Util.noCircularReplaceHelper()))
+            .toStrictEqual(JSON.stringify({ parent: { child: { value: 10 } } }));
+    });
 });


### PR DESCRIPTION
Ticket: #492 

The code implemented is for a new class to send execution results to "bespoken-api" endpoint. 
This new class executes after JEST completes the execution of all suites and it pushes the results to the endpoint.

Environment variable was added for point the "bespoken-api".
Name: BESPOKEN_API_BASE_URL
Default value: https://bespoken-api.bespoken.tools

Also, it was removed the code related to "saveTestResults", "getSourceExists" and its dependencies in the unit tests.
