### PR TITLE
Adding limit for random token in trace file name

### DIFF
--- a/lib/runner/TraceOutput.js
+++ b/lib/runner/TraceOutput.js
@@ -16,7 +16,7 @@ const shortName = longName => longName.split(/[^a-z0-9]/ig)
     .map(p => upperFirst(camelCase(p)))
     .reduce((p, c) => p.length <= 20 ? p.concat(c) : p, "");
 
-const createSHA = name => crypto.createHash("shake256", { outputLength: 2 }).update(name).digest("hex");
+const createSHA = name => crypto.createHash("shake256", { outputLength: 2 }).update(name).digest("hex").substring(0,4);
 
 const formatTimeStamp = milliseconds => new Date(milliseconds).toISOString().split(/[^0-9]/).filter(f => f).join("");
 


### PR DESCRIPTION
- When trace log files are created random key is added. This key is limited by using substring  